### PR TITLE
feat: workout history, detail view, and volume trends (Step 7)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@tanstack/react-query": "^5.95.2",
         "@tanstack/react-router": "^1.168.7",
         "@tanstack/react-router-devtools": "^1.166.11",
+        "@tanstack/react-virtual": "^3.13.23",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.7.0",
@@ -490,6 +491,8 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.23", "", { "dependencies": { "@tanstack/virtual-core": "3.13.23" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ=="],
+
     "@tanstack/router-core": ["@tanstack/router-core@1.168.6", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-okCno3pImpLFQMJ/4zqEIGjIV5yhxLGj0JByrzQDQehORN1y1q6lJUezT0KPK5qCQiKUApeWaboLPjgBVx1kaQ=="],
 
     "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.167.1", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.168.2", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-ECMM47J4KmifUvJguGituSiBpfN8SyCUEoxQks5RY09hpIBfR2eswCv2e6cJimjkKwBQXOVTPkTUk/yRvER+9w=="],
@@ -501,6 +504,8 @@
     "@tanstack/router-utils": ["@tanstack/router-utils@1.161.6", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.23", "", {}, "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-query": "^5.95.2",
     "@tanstack/react-router": "^1.168.7",
     "@tanstack/react-router-devtools": "^1.166.11",
+    "@tanstack/react-virtual": "^3.13.23",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",

--- a/src/components/exercises/exercise-history-list.tsx
+++ b/src/components/exercises/exercise-history-list.tsx
@@ -1,8 +1,16 @@
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+import { formatDuration } from '@/lib/format-duration'
+import { VolumeLoadBar } from '@/components/history/volume-load-bar'
 import type { WorkoutLog, LoggedSet } from '@/domain/types'
 
 interface ExerciseHistoryListProps {
   history: { log: WorkoutLog; sets: LoggedSet[] }[]
 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function formatHistoryDate(dateStr: string): string {
   const d = new Date(dateStr)
@@ -24,7 +32,57 @@ function getWeightRange(sets: LoggedSet[]): string {
   return `${min}-${max}lb`
 }
 
+function computeVolume(sets: LoggedSet[]): number {
+  return sets
+    .filter((s) => s.completed && s.actualReps != null && s.actualWeight != null)
+    .reduce((sum, s) => sum + (s.actualWeight?.value ?? 0) * (s.actualReps ?? 0), 0)
+}
+
+function formatVolume(vol: number): string {
+  if (vol >= 1000) return `${(vol / 1000).toFixed(1)}K`
+  return `${Math.round(vol)}`
+}
+
+function formatSetDetail(set: LoggedSet): string {
+  const parts: string[] = []
+
+  if (set.actualWeight?.value != null) {
+    parts.push(`${set.actualWeight.value}${set.actualWeight.unit}`)
+  }
+
+  if (set.actualReps != null) {
+    if (parts.length > 0) {
+      parts.push(`x ${set.actualReps}`)
+    } else {
+      parts.push(`${set.actualReps} reps`)
+    }
+  }
+
+  if (set.actualDuration != null) {
+    parts.push(formatDuration(set.actualDuration.seconds))
+  }
+
+  if (set.actualDistance != null) {
+    const dist = set.actualDistance
+    parts.push(`${dist.value}${dist.unit}`)
+  }
+
+  if (parts.length === 0) return '--'
+  return parts.join(' ')
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export function ExerciseHistoryList({ history }: ExerciseHistoryListProps) {
+  // Last 3 sessions expanded by default
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    const initial = new Set<string>()
+    history.slice(0, 3).forEach(({ log }) => initial.add(log.id))
+    return initial
+  })
+
   if (!history || history.length === 0) {
     return (
       <div className="flex items-center justify-center px-4 py-16">
@@ -35,44 +93,138 @@ export function ExerciseHistoryList({ history }: ExerciseHistoryListProps) {
     )
   }
 
+  const maxVolume = Math.max(...history.map(({ sets }) => computeVolume(sets)), 0)
+
+  function toggleSession(logId: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(logId)) {
+        next.delete(logId)
+      } else {
+        next.add(logId)
+      }
+      return next
+    })
+  }
+
   return (
-    <div className="space-y-0">
-      {history.map(({ log, sets }) => (
-        <div
-          key={log.id}
-          className="border-b border-b-[rgba(91,64,57,0.15)] bg-surface-iron px-4 py-3"
-        >
-          <div className="flex items-center justify-between">
-            <span className="font-body text-xs font-medium uppercase tracking-widest text-warm-ash">
-              {formatHistoryDate(log.startedAt)}
-            </span>
-            <span className="text-xs text-warm-ash/60">{log.title || 'Untitled session'}</span>
-          </div>
-          <div className="mt-1.5 flex gap-4">
-            <div>
-              <span className="text-xs text-warm-ash/60">SETS</span>
-              <span className="ml-1 font-display text-sm text-bone-white">{sets.length}</span>
-            </div>
-            <div>
-              <span className="text-xs text-warm-ash/60">WEIGHT</span>
-              <span className="ml-1 font-display text-sm text-bone-white">
-                {getWeightRange(sets)}
-              </span>
-            </div>
-            {sets.some((s) => s.actualReps !== undefined) && (
-              <div>
-                <span className="text-xs text-warm-ash/60">REPS</span>
-                <span className="ml-1 font-display text-sm text-bone-white">
-                  {sets
-                    .map((s) => s.actualReps)
-                    .filter((r): r is number => r !== undefined)
-                    .join(', ')}
+    <div>
+      {history.map(({ log, sets }, idx) => {
+        const isExpanded = expanded.has(log.id)
+        const volume = computeVolume(sets)
+        const stripeBg = idx % 2 === 0 ? 'bg-surface-iron' : 'bg-surface-charcoal'
+
+        return (
+          <div key={log.id}>
+            {/* Session header -- tappable to expand/collapse */}
+            <button
+              type="button"
+              onClick={() => toggleSession(log.id)}
+              className={cn(
+                'flex min-h-12 w-full items-center justify-between border-b border-b-[rgba(91,64,57,0.15)] px-4 py-3 text-left',
+                stripeBg,
+              )}
+              aria-expanded={isExpanded}
+              aria-controls={`session-${log.id}`}
+            >
+              <div className="flex flex-col gap-0.5">
+                <span className="font-body text-xs font-medium uppercase tracking-widest text-warm-ash">
+                  {formatHistoryDate(log.startedAt)}
                 </span>
+                <span className="text-[10px] text-warm-ash/50">
+                  {log.title || 'Untitled session'}
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                {/* Summary badges */}
+                <div className="flex gap-2">
+                  <span className="font-body text-[10px] uppercase text-warm-ash/60">
+                    {sets.length}S
+                  </span>
+                  <span className="font-body text-[10px] uppercase text-warm-ash/60">
+                    {getWeightRange(sets)}
+                  </span>
+                  {volume > 0 && (
+                    <span className="font-display text-xs font-medium text-ember">
+                      {formatVolume(volume)}
+                    </span>
+                  )}
+                </div>
+                <span
+                  className={cn(
+                    'material-symbols-outlined text-base text-warm-ash/40 transition-transform',
+                    isExpanded && 'rotate-180',
+                  )}
+                >
+                  expand_more
+                </span>
+              </div>
+            </button>
+
+            {/* Expanded detail */}
+            {isExpanded && (
+              <div
+                id={`session-${log.id}`}
+                className={cn('border-b border-b-[rgba(91,64,57,0.15)]', stripeBg)}
+              >
+                {/* Set-by-set rows */}
+                <div className="px-4 pt-2 pb-1">
+                  {sets
+                    .slice()
+                    .sort((a, b) => a.setNumber - b.setNumber)
+                    .map((set) => (
+                      <div
+                        key={set.id}
+                        className="flex min-h-8 items-center justify-between py-1 pl-4"
+                      >
+                        <div className="flex items-center gap-2">
+                          <span className="font-body text-[10px] uppercase text-warm-ash/50">
+                            SET {set.setNumber}
+                          </span>
+                          {set.setType !== 'WORKING' && (
+                            <span className="bg-surface-steel px-1.5 py-0.5 font-body text-[9px] uppercase tracking-wider text-warm-ash/60">
+                              {set.setType}
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="font-display text-xs text-bone-white">
+                            {formatSetDetail(set)}
+                          </span>
+                          {set.rpe != null && (
+                            <span className="font-body text-[10px] text-warm-ash/50">
+                              RPE {set.rpe}
+                            </span>
+                          )}
+                          {set.completed ? (
+                            <span className="material-symbols-outlined text-sm text-ember">
+                              check_circle
+                            </span>
+                          ) : (
+                            <span className="material-symbols-outlined text-sm text-warm-ash/30">
+                              radio_button_unchecked
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                </div>
+
+                {/* Volume load bar */}
+                {volume > 0 && (
+                  <div className="px-4 pt-1 pb-3">
+                    <VolumeLoadBar
+                      value={volume}
+                      maxValue={maxVolume}
+                      label={`${formatVolume(volume)} vol`}
+                    />
+                  </div>
+                )}
               </div>
             )}
           </div>
-        </div>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/src/components/history/delete-workout-dialog.tsx
+++ b/src/components/history/delete-workout-dialog.tsx
@@ -1,0 +1,67 @@
+import { useDeleteWorkoutLog } from '@/hooks/use-workout-logs'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface DeleteWorkoutDialogProps {
+  workoutId: string
+  open: boolean
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export function DeleteWorkoutDialog({
+  workoutId,
+  open,
+  onClose,
+  onSuccess,
+}: DeleteWorkoutDialogProps) {
+  const deleteWorkoutLog = useDeleteWorkoutLog()
+
+  const handleDelete = async () => {
+    try {
+      await deleteWorkoutLog.mutateAsync(workoutId)
+      onSuccess()
+    } catch {
+      // Error state available via deleteWorkoutLog.isError
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle className="text-xs uppercase tracking-widest text-warning-flare">
+            DELETE WORKOUT
+          </DialogTitle>
+          <DialogDescription>
+            This workout and all its logged sets will be permanently deleted. This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={deleteWorkoutLog.isPending}>
+            CANCEL
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={deleteWorkoutLog.isPending}
+          >
+            {deleteWorkoutLog.isPending ? 'DELETING...' : 'DELETE'}
+          </Button>
+        </DialogFooter>
+        {deleteWorkoutLog.isError && (
+          <p className="text-xs text-warning-flare px-4 pb-2">
+            Failed to delete workout. Please try again.
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/history/volume-load-bar.tsx
+++ b/src/components/history/volume-load-bar.tsx
@@ -1,0 +1,25 @@
+import { cn } from '@/lib/utils'
+
+interface VolumeLoadBarProps {
+  value: number
+  maxValue: number
+  label?: string
+  className?: string
+}
+
+export function VolumeLoadBar({ value, maxValue, label, className }: VolumeLoadBarProps) {
+  const widthPct = maxValue > 0 ? Math.round((value / maxValue) * 100) : 0
+
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      {label && (
+        <span className="w-16 shrink-0 text-right font-body text-xs tabular-nums text-warm-ash">
+          {label}
+        </span>
+      )}
+      <div className="h-[8px] flex-1 bg-surface-steel">
+        <div className="h-full bg-ember transition-all" style={{ width: `${widthPct}%` }} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/history/workout-detail-exercises.tsx
+++ b/src/components/history/workout-detail-exercises.tsx
@@ -1,0 +1,162 @@
+import { formatDuration } from '@/lib/format-duration'
+import { Icon } from '@/components/icon'
+import type { Exercise, LoggedActivityGroup, LoggedActivity, LoggedSet } from '@/domain/types'
+
+interface WorkoutDetailExercisesProps {
+  groups: LoggedActivityGroup[]
+  activities: LoggedActivity[]
+  sets: LoggedSet[]
+  exercises: Exercise[]
+}
+
+function formatActualValue(set: LoggedSet): string {
+  // Weight-based sets
+  if (set.actualWeight != null && set.actualReps != null) {
+    return `${set.actualWeight.value}${set.actualWeight.unit} x ${set.actualReps}`
+  }
+
+  // Weight only
+  if (set.actualWeight != null) {
+    return `${set.actualWeight.value}${set.actualWeight.unit}`
+  }
+
+  // Duration-based sets
+  if (set.actualDuration != null) {
+    return formatDuration(set.actualDuration.seconds)
+  }
+
+  // Distance-based sets
+  if (set.actualDistance != null) {
+    return `${set.actualDistance.value} ${set.actualDistance.unit}`
+  }
+
+  // Reps only
+  if (set.actualReps != null) {
+    return `${set.actualReps} reps`
+  }
+
+  return '--'
+}
+
+export function WorkoutDetailExercises({
+  groups,
+  activities,
+  sets,
+  exercises,
+}: WorkoutDetailExercisesProps) {
+  // Build lookup maps
+  const exerciseMap = new Map<string, Exercise>()
+  for (const ex of exercises) {
+    exerciseMap.set(ex.id, ex)
+  }
+
+  const activitiesByGroup = new Map<string, LoggedActivity[]>()
+  for (const activity of activities) {
+    const list = activitiesByGroup.get(activity.loggedGroupId) ?? []
+    list.push(activity)
+    activitiesByGroup.set(activity.loggedGroupId, list)
+  }
+
+  const setsByActivity = new Map<string, LoggedSet[]>()
+  for (const set of sets) {
+    const list = setsByActivity.get(set.loggedActivityId) ?? []
+    list.push(set)
+    setsByActivity.set(set.loggedActivityId, list)
+  }
+
+  // Sort groups by ordinal
+  const sortedGroups = [...groups].sort((a, b) => a.ordinal - b.ordinal)
+
+  if (sortedGroups.length === 0) {
+    return (
+      <div className="flex items-center justify-center px-4 py-16">
+        <p className="font-display text-sm uppercase tracking-widest text-warm-ash">
+          NO EXERCISES LOGGED
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6 px-4 pb-8">
+      {sortedGroups.map((group) => {
+        const groupActivities = (activitiesByGroup.get(group.id) ?? []).sort(
+          (a, b) => a.ordinal - b.ordinal,
+        )
+
+        return groupActivities.map((activity) => {
+          const exercise = exerciseMap.get(activity.exerciseId)
+          const activitySets = (setsByActivity.get(activity.id) ?? []).sort(
+            (a, b) => a.setNumber - b.setNumber,
+          )
+
+          return (
+            <div key={activity.id}>
+              {/* Exercise name header */}
+              <h3 className="text-xs font-medium uppercase tracking-widest text-warm-ash mb-2">
+                {exercise?.name ?? 'Unknown Exercise'}
+              </h3>
+
+              {/* Data table */}
+              <div className="w-full">
+                {/* Column headers */}
+                <div className="flex items-center py-1.5">
+                  <span className="w-12 text-center text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
+                    SET
+                  </span>
+                  <span className="flex-1 text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
+                    ACTUAL
+                  </span>
+                  <span className="w-24 text-center text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
+                    STATUS
+                  </span>
+                </div>
+
+                {/* Set rows */}
+                {activitySets.map((set, setIdx) => (
+                  <div
+                    key={set.id}
+                    className={`flex items-center py-2 ${
+                      setIdx % 2 === 0 ? 'bg-surface-iron' : 'bg-surface-charcoal'
+                    }`}
+                  >
+                    {/* Set number */}
+                    <span className="w-12 text-center font-display text-sm tabular-nums text-bone-white">
+                      {set.setNumber}
+                    </span>
+
+                    {/* Actual values */}
+                    <span className="flex-1 font-display text-sm tabular-nums text-bone-white">
+                      {formatActualValue(set)}
+                    </span>
+
+                    {/* Status badge */}
+                    <div className="w-24 flex justify-center">
+                      {set.completed ? (
+                        <span className="inline-flex items-center gap-1 bg-forge text-on-forge text-[10px] px-2 py-0.5 uppercase tracking-widest">
+                          <Icon name="check" size={12} />
+                          DONE
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center bg-surface-gunmetal text-warm-ash text-[10px] px-2 py-0.5 uppercase tracking-widest">
+                          SKIP
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+
+                {/* Activity notes */}
+                {activity.notes && (
+                  <div className="mt-1 px-3 py-1.5">
+                    <span className="text-xs text-warm-ash/60 italic">{activity.notes}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          )
+        })
+      })}
+    </div>
+  )
+}

--- a/src/components/history/workout-detail-header.tsx
+++ b/src/components/history/workout-detail-header.tsx
@@ -1,0 +1,114 @@
+import { Link } from '@tanstack/react-router'
+import { formatDateLabel, formatDuration } from '@/lib/format-duration'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Icon } from '@/components/icon'
+import type { WorkoutLog, LoggedSet } from '@/domain/types'
+
+interface WorkoutDetailHeaderProps {
+  log: WorkoutLog
+  allSets: LoggedSet[]
+  onDelete: () => void
+}
+
+export function WorkoutDetailHeader({ log, allSets, onDelete }: WorkoutDetailHeaderProps) {
+  const startedAt = new Date(log.startedAt)
+  const completedAt = log.completedAt ? new Date(log.completedAt) : null
+
+  const durationSeconds = completedAt
+    ? Math.floor((completedAt.getTime() - startedAt.getTime()) / 1000)
+    : null
+
+  const dateLabel = formatDateLabel(startedAt)
+
+  // Total volume: sum of (actualWeight.value * actualReps) for completed sets
+  const totalVolume = allSets.reduce((acc, set) => {
+    if (!set.completed) return acc
+    const weight = set.actualWeight?.value ?? 0
+    const reps = set.actualReps ?? 0
+    return acc + weight * reps
+  }, 0)
+
+  return (
+    <div className="bg-surface-anvil">
+      {/* Back button + title row */}
+      <div className="flex items-center gap-3 px-4 pt-6 pb-2">
+        <Link
+          to="/history"
+          className="flex min-h-12 min-w-12 items-center justify-center text-warm-ash"
+          aria-label="Back to history"
+        >
+          <Icon name="arrow_back" size={20} />
+        </Link>
+        <h1 className="font-heading text-xl font-medium text-bone-white">
+          {log.title ?? dateLabel}
+        </h1>
+      </div>
+
+      {/* Duration readout */}
+      {durationSeconds != null && (
+        <div className="flex flex-col items-center py-4">
+          <span className="text-readout text-bone-white">{formatDuration(durationSeconds)}</span>
+          <span className="mt-1 text-[10px] uppercase tracking-widest text-warm-ash/60">
+            DURATION
+          </span>
+        </div>
+      )}
+
+      {/* Stats row */}
+      <div className="flex gap-0 px-4 pb-4">
+        <div className="flex flex-1 flex-col items-center bg-surface-iron py-3">
+          <span className="font-display text-2xl tabular-nums text-bone-white">
+            {allSets.filter((s) => s.completed).length}
+          </span>
+          <span className="text-[10px] uppercase tracking-widest text-warm-ash/60">SETS</span>
+        </div>
+        <div className="flex flex-1 flex-col items-center bg-surface-iron py-3">
+          <span className="font-display text-2xl tabular-nums text-bone-white">
+            {totalVolume > 0 ? Math.round(totalVolume).toLocaleString() : '--'}
+          </span>
+          <span className="text-[10px] uppercase tracking-widest text-warm-ash/60">VOLUME</span>
+        </div>
+        {log.perceivedDifficulty != null && (
+          <div className="flex flex-1 flex-col items-center bg-surface-iron py-3">
+            <span className="font-display text-2xl tabular-nums text-bone-white">
+              {log.perceivedDifficulty}
+            </span>
+            <span className="text-[10px] uppercase tracking-widest text-warm-ash/60">RPE</span>
+          </div>
+        )}
+      </div>
+
+      {/* Notes block */}
+      {log.overallNotes && (
+        <div className="px-4 pb-4">
+          <span className="block text-[10px] uppercase tracking-widest text-warm-ash/60 mb-1">
+            NOTES
+          </span>
+          <p className="text-sm text-bone-white bg-surface-iron px-3 py-2">{log.overallNotes}</p>
+        </div>
+      )}
+
+      {/* Program context */}
+      {log.programContext && (
+        <div className="px-4 pb-4">
+          <Badge className="bg-surface-gunmetal text-bone-white text-xs px-2 py-0.5 uppercase tracking-widest">
+            PROGRAM: {log.programContext.dayLabel}
+          </Badge>
+        </div>
+      )}
+
+      {/* Delete button */}
+      <div className="px-4 pb-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDelete}
+          className="w-full text-xs text-warning-flare uppercase tracking-widest"
+        >
+          DELETE WORKOUT
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/history/workout-history-card.tsx
+++ b/src/components/history/workout-history-card.tsx
@@ -1,0 +1,55 @@
+import { formatDateLabel, formatDuration } from '@/lib/format-duration'
+import { Badge } from '@/components/ui/badge'
+import type { WorkoutLogSummary } from '@/lib/data-adapter'
+
+interface WorkoutHistoryCardProps {
+  summary: WorkoutLogSummary
+  index: number
+  onClick: () => void
+}
+
+export function WorkoutHistoryCard({ summary, index, onClick }: WorkoutHistoryCardProps) {
+  const { log, exerciseNames, setCount } = summary
+  const startedAt = new Date(log.startedAt)
+  const completedAt = log.completedAt ? new Date(log.completedAt) : null
+
+  const durationSeconds = completedAt
+    ? Math.floor((completedAt.getTime() - startedAt.getTime()) / 1000)
+    : null
+
+  const dateLabel = formatDateLabel(startedAt)
+  const exerciseList = exerciseNames.join(', ')
+
+  const isEven = index % 2 === 0
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex w-full min-h-[60px] items-center justify-between px-4 py-3 cursor-pointer text-left transition-colors active:brightness-125 ${
+        isEven ? 'bg-surface-iron' : 'bg-surface-charcoal'
+      }`}
+      aria-label={`View workout from ${dateLabel}`}
+    >
+      {/* Left side: date + exercise names */}
+      <div className="flex flex-col gap-0.5 min-w-0 flex-1 mr-3">
+        <span className="font-heading text-sm text-bone-white uppercase tracking-wider">
+          {log.title ?? dateLabel}
+        </span>
+        <span className="text-xs text-warm-ash/60 truncate">{exerciseList || 'No exercises'}</span>
+      </div>
+
+      {/* Right side: duration + set count badge */}
+      <div className="flex items-center gap-2 shrink-0">
+        {durationSeconds != null && (
+          <span className="font-display text-sm text-warm-ash tabular-nums">
+            {formatDuration(durationSeconds)}
+          </span>
+        )}
+        <Badge className="bg-surface-gunmetal text-bone-white text-xs px-2 py-0.5 uppercase tracking-widest">
+          {setCount} {setCount === 1 ? 'SET' : 'SETS'}
+        </Badge>
+      </div>
+    </button>
+  )
+}

--- a/src/hooks/use-workout-logs.ts
+++ b/src/hooks/use-workout-logs.ts
@@ -18,6 +18,14 @@ export function useWorkoutLog(id: string) {
   })
 }
 
+export function useWorkoutLogsSummary(userId: string, limit?: number) {
+  return useQuery({
+    queryKey: ['workoutLogsSummary', userId, limit],
+    queryFn: () => getAdapter().getWorkoutLogsSummary(userId, { limit }),
+    enabled: !!userId,
+  })
+}
+
 export function useWorkoutLogFull(id: string) {
   return useQuery({
     queryKey: ['workout-full', id],

--- a/src/lib/data-adapter.ts
+++ b/src/lib/data-adapter.ts
@@ -11,6 +11,13 @@ import type { ExerciseCategory, MovementPattern, MuscleGroup } from '@/domain/ty
 
 export type WorkoutWithSets = { log: WorkoutLog; sets: LoggedSet[] }
 
+export type WorkoutLogSummary = {
+  log: WorkoutLog
+  exerciseNames: string[]
+  setCount: number
+  exerciseCount: number
+}
+
 export interface ExerciseFilters {
   category?: ExerciseCategory
   movementPattern?: MovementPattern
@@ -38,6 +45,10 @@ export interface DataAdapter {
 
   // Workout log operations
   getWorkoutLogs(userId: string, limit?: number): Promise<WorkoutLog[]>
+  getWorkoutLogsSummary(
+    userId: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<WorkoutLogSummary[]>
   getWorkoutLog(id: string): Promise<WorkoutLog | null>
   getWorkoutLogFull(id: string): Promise<{
     log: WorkoutLog

--- a/src/lib/supabase-adapter.ts
+++ b/src/lib/supabase-adapter.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { DataAdapter, ExerciseFilters } from './data-adapter'
+import type { DataAdapter, ExerciseFilters, WorkoutLogSummary } from './data-adapter'
 import type {
   Exercise,
   WorkoutLog,
@@ -147,6 +147,66 @@ export class SupabaseAdapter implements DataAdapter {
     const { data, error } = await query
     if (error) throw error
     return (data as WorkoutLogRow[]).map(toWorkoutLog)
+  }
+
+  async getWorkoutLogsSummary(
+    userId: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<WorkoutLogSummary[]> {
+    let query = this.client
+      .from('workout_logs')
+      .select(
+        '*, logged_activity_groups(logged_activities(exercises(name), logged_sets(id, completed)))',
+      )
+      .eq('user_id', userId)
+      .not('completed_at', 'is', null)
+      .order('started_at', { ascending: false })
+
+    if (options?.limit) {
+      query = query.limit(options.limit)
+    }
+    if (options?.offset) {
+      query = query.range(options.offset, options.offset + (options.limit ?? 50) - 1)
+    }
+
+    const { data, error } = await query
+    if (error) throw error
+
+    // Shape returned by the nested PostgREST select
+    type NestedRow = WorkoutLogRow & {
+      logged_activity_groups: Array<{
+        logged_activities: Array<{
+          exercises: { name: string } | null
+          logged_sets: Array<{ id: string; completed: boolean }>
+        }>
+      }>
+    }
+    const rows = data as unknown as NestedRow[]
+
+    return rows.map((row) => {
+      const exerciseNameSet = new Set<string>()
+      let setCount = 0
+
+      for (const group of row.logged_activity_groups) {
+        for (const activity of group.logged_activities) {
+          if (activity.exercises?.name) {
+            exerciseNameSet.add(activity.exercises.name)
+          }
+          for (const set of activity.logged_sets) {
+            if (set.completed) {
+              setCount++
+            }
+          }
+        }
+      }
+
+      return {
+        log: toWorkoutLog(row as unknown as WorkoutLogRow),
+        exerciseNames: Array.from(exerciseNameSet),
+        setCount,
+        exerciseCount: exerciseNameSet.size,
+      }
+    })
   }
 
   async getWorkoutLog(id: string): Promise<WorkoutLog | null> {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -20,8 +20,10 @@ import { Route as BuilderRouteImport } from './routes/builder'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/index'
 import { Route as AuthenticatedProfileRouteImport } from './routes/_authenticated/profile'
+import { Route as AuthenticatedHistoryIndexRouteImport } from './routes/_authenticated/history/index'
 import { Route as AuthenticatedExercisesIndexRouteImport } from './routes/_authenticated/exercises/index'
 import { Route as AuthenticatedLogWorkoutIdRouteImport } from './routes/_authenticated/log.$workoutId'
+import { Route as AuthenticatedHistoryWorkoutIdRouteImport } from './routes/_authenticated/history/$workoutId'
 import { Route as AuthenticatedExercisesExerciseIdRouteImport } from './routes/_authenticated/exercises/$exerciseId'
 
 const VaultRoute = VaultRouteImport.update({
@@ -78,6 +80,12 @@ const AuthenticatedProfileRoute = AuthenticatedProfileRouteImport.update({
   path: '/profile',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedHistoryIndexRoute =
+  AuthenticatedHistoryIndexRouteImport.update({
+    id: '/history/',
+    path: '/history/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedExercisesIndexRoute =
   AuthenticatedExercisesIndexRouteImport.update({
     id: '/exercises/',
@@ -88,6 +96,12 @@ const AuthenticatedLogWorkoutIdRoute =
   AuthenticatedLogWorkoutIdRouteImport.update({
     id: '/log/$workoutId',
     path: '/log/$workoutId',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+const AuthenticatedHistoryWorkoutIdRoute =
+  AuthenticatedHistoryWorkoutIdRouteImport.update({
+    id: '/history/$workoutId',
+    path: '/history/$workoutId',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 const AuthenticatedExercisesExerciseIdRoute =
@@ -109,8 +123,10 @@ export interface FileRoutesByFullPath {
   '/vault': typeof VaultRoute
   '/profile': typeof AuthenticatedProfileRoute
   '/exercises/$exerciseId': typeof AuthenticatedExercisesExerciseIdRoute
+  '/history/$workoutId': typeof AuthenticatedHistoryWorkoutIdRoute
   '/log/$workoutId': typeof AuthenticatedLogWorkoutIdRoute
   '/exercises/': typeof AuthenticatedExercisesIndexRoute
+  '/history/': typeof AuthenticatedHistoryIndexRoute
 }
 export interface FileRoutesByTo {
   '/builder': typeof BuilderRoute
@@ -124,8 +140,10 @@ export interface FileRoutesByTo {
   '/profile': typeof AuthenticatedProfileRoute
   '/': typeof AuthenticatedIndexRoute
   '/exercises/$exerciseId': typeof AuthenticatedExercisesExerciseIdRoute
+  '/history/$workoutId': typeof AuthenticatedHistoryWorkoutIdRoute
   '/log/$workoutId': typeof AuthenticatedLogWorkoutIdRoute
   '/exercises': typeof AuthenticatedExercisesIndexRoute
+  '/history': typeof AuthenticatedHistoryIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -141,8 +159,10 @@ export interface FileRoutesById {
   '/_authenticated/profile': typeof AuthenticatedProfileRoute
   '/_authenticated/': typeof AuthenticatedIndexRoute
   '/_authenticated/exercises/$exerciseId': typeof AuthenticatedExercisesExerciseIdRoute
+  '/_authenticated/history/$workoutId': typeof AuthenticatedHistoryWorkoutIdRoute
   '/_authenticated/log/$workoutId': typeof AuthenticatedLogWorkoutIdRoute
   '/_authenticated/exercises/': typeof AuthenticatedExercisesIndexRoute
+  '/_authenticated/history/': typeof AuthenticatedHistoryIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -158,8 +178,10 @@ export interface FileRouteTypes {
     | '/vault'
     | '/profile'
     | '/exercises/$exerciseId'
+    | '/history/$workoutId'
     | '/log/$workoutId'
     | '/exercises/'
+    | '/history/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/builder'
@@ -173,8 +195,10 @@ export interface FileRouteTypes {
     | '/profile'
     | '/'
     | '/exercises/$exerciseId'
+    | '/history/$workoutId'
     | '/log/$workoutId'
     | '/exercises'
+    | '/history'
   id:
     | '__root__'
     | '/_authenticated'
@@ -189,8 +213,10 @@ export interface FileRouteTypes {
     | '/_authenticated/profile'
     | '/_authenticated/'
     | '/_authenticated/exercises/$exerciseId'
+    | '/_authenticated/history/$workoutId'
     | '/_authenticated/log/$workoutId'
     | '/_authenticated/exercises/'
+    | '/_authenticated/history/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -284,6 +310,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProfileRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/history/': {
+      id: '/_authenticated/history/'
+      path: '/history'
+      fullPath: '/history/'
+      preLoaderRoute: typeof AuthenticatedHistoryIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/exercises/': {
       id: '/_authenticated/exercises/'
       path: '/exercises'
@@ -296,6 +329,13 @@ declare module '@tanstack/react-router' {
       path: '/log/$workoutId'
       fullPath: '/log/$workoutId'
       preLoaderRoute: typeof AuthenticatedLogWorkoutIdRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/history/$workoutId': {
+      id: '/_authenticated/history/$workoutId'
+      path: '/history/$workoutId'
+      fullPath: '/history/$workoutId'
+      preLoaderRoute: typeof AuthenticatedHistoryWorkoutIdRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/exercises/$exerciseId': {
@@ -312,16 +352,20 @@ interface AuthenticatedRouteChildren {
   AuthenticatedProfileRoute: typeof AuthenticatedProfileRoute
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
   AuthenticatedExercisesExerciseIdRoute: typeof AuthenticatedExercisesExerciseIdRoute
+  AuthenticatedHistoryWorkoutIdRoute: typeof AuthenticatedHistoryWorkoutIdRoute
   AuthenticatedLogWorkoutIdRoute: typeof AuthenticatedLogWorkoutIdRoute
   AuthenticatedExercisesIndexRoute: typeof AuthenticatedExercisesIndexRoute
+  AuthenticatedHistoryIndexRoute: typeof AuthenticatedHistoryIndexRoute
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedProfileRoute: AuthenticatedProfileRoute,
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
   AuthenticatedExercisesExerciseIdRoute: AuthenticatedExercisesExerciseIdRoute,
+  AuthenticatedHistoryWorkoutIdRoute: AuthenticatedHistoryWorkoutIdRoute,
   AuthenticatedLogWorkoutIdRoute: AuthenticatedLogWorkoutIdRoute,
   AuthenticatedExercisesIndexRoute: AuthenticatedExercisesIndexRoute,
+  AuthenticatedHistoryIndexRoute: AuthenticatedHistoryIndexRoute,
 }
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -26,6 +26,7 @@ interface NavItem {
 
 const NAV_ITEMS: NavItem[] = [
   { to: '/', label: 'FORGE', icon: 'home' },
+  { to: '/history', label: 'TRACKER', icon: 'history' },
   { to: '/exercises', label: 'LIBRARY', icon: 'fitness_center' },
   { to: '/profile', label: 'PROFILE', icon: 'person' },
 ]

--- a/src/routes/_authenticated/history/$workoutId.tsx
+++ b/src/routes/_authenticated/history/$workoutId.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useWorkoutLogFull } from '@/hooks/use-workout-logs'
+import { useExercises } from '@/hooks/use-exercises'
+import { WorkoutDetailHeader } from '@/components/history/workout-detail-header'
+import { WorkoutDetailExercises } from '@/components/history/workout-detail-exercises'
+import { DeleteWorkoutDialog } from '@/components/history/delete-workout-dialog'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Link } from '@tanstack/react-router'
+import { Icon } from '@/components/icon'
+
+export const Route = createFileRoute('/_authenticated/history/$workoutId')({
+  component: WorkoutDetailPage,
+})
+
+function WorkoutDetailSkeleton() {
+  return (
+    <div className="min-h-[100dvh] bg-surface-anvil">
+      {/* Back button skeleton */}
+      <div className="flex items-center gap-3 px-4 pt-6 pb-2">
+        <Skeleton className="h-12 w-12 rounded-none bg-surface-steel" />
+        <Skeleton className="h-6 w-48 rounded-none bg-surface-steel" />
+      </div>
+
+      {/* Duration skeleton */}
+      <div className="flex flex-col items-center py-4">
+        <Skeleton className="h-14 w-32 rounded-none bg-surface-steel" />
+        <Skeleton className="mt-2 h-3 w-16 rounded-none bg-surface-steel" />
+      </div>
+
+      {/* Stats row skeleton */}
+      <div className="flex gap-0 px-4 pb-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex flex-1 flex-col items-center bg-surface-iron py-3">
+            <Skeleton className="h-8 w-12 rounded-none bg-surface-steel" />
+            <Skeleton className="mt-1 h-3 w-10 rounded-none bg-surface-steel" />
+          </div>
+        ))}
+      </div>
+
+      {/* Exercise blocks skeleton */}
+      <div className="flex flex-col gap-6 px-4 pb-8">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i}>
+            <Skeleton className="mb-2 h-4 w-40 rounded-none bg-surface-steel" />
+            {Array.from({ length: 3 }).map((_, j) => (
+              <div
+                key={j}
+                className={`flex items-center py-2 ${j % 2 === 0 ? 'bg-surface-iron' : 'bg-surface-charcoal'}`}
+              >
+                <Skeleton className="ml-3 h-4 w-8 rounded-none bg-surface-steel" />
+                <Skeleton className="ml-4 h-4 w-24 rounded-none bg-surface-steel" />
+                <Skeleton className="ml-auto mr-3 h-5 w-14 rounded-none bg-surface-steel" />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function WorkoutDetailPage() {
+  const { workoutId } = Route.useParams()
+  const navigate = useNavigate()
+
+  const { data: workoutData, isLoading, isError } = useWorkoutLogFull(workoutId)
+  const { data: exercises = [] } = useExercises()
+
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+
+  const handleDeleteSuccess = () => {
+    setShowDeleteDialog(false)
+    navigate({ to: '/history' })
+  }
+
+  if (isLoading) {
+    return <WorkoutDetailSkeleton />
+  }
+
+  if (isError) {
+    return (
+      <div className="flex min-h-[100dvh] flex-col items-center justify-center bg-surface-anvil px-4">
+        <span className="material-symbols-outlined mb-3 text-4xl text-warning-flare">
+          cloud_off
+        </span>
+        <p className="font-display text-sm uppercase tracking-widest text-warning-flare">
+          FAILED TO LOAD WORKOUT
+        </p>
+        <p className="mt-2 text-xs text-warm-ash">Check your connection and try again.</p>
+        <Link to="/history" className="mt-4 text-xs uppercase tracking-widest text-ember">
+          BACK TO HISTORY
+        </Link>
+      </div>
+    )
+  }
+
+  if (!workoutData) {
+    return (
+      <div className="flex min-h-[100dvh] flex-col items-center justify-center bg-surface-anvil px-4">
+        <Icon name="error_outline" size={48} className="mb-3 text-warm-ash/40" />
+        <p className="font-display text-sm uppercase tracking-widest text-warm-ash">
+          WORKOUT NOT FOUND
+        </p>
+        <Link to="/history" className="mt-4 text-xs uppercase tracking-widest text-ember">
+          BACK TO HISTORY
+        </Link>
+      </div>
+    )
+  }
+
+  const { log, groups, activities, sets } = workoutData
+
+  return (
+    <div className="min-h-[100dvh] bg-surface-anvil">
+      <WorkoutDetailHeader log={log} allSets={sets} onDelete={() => setShowDeleteDialog(true)} />
+
+      {/* Exercise breakdown */}
+      <WorkoutDetailExercises
+        groups={groups}
+        activities={activities}
+        sets={sets}
+        exercises={exercises}
+      />
+
+      {/* Delete dialog */}
+      <DeleteWorkoutDialog
+        workoutId={workoutId}
+        open={showDeleteDialog}
+        onClose={() => setShowDeleteDialog(false)}
+        onSuccess={handleDeleteSuccess}
+      />
+    </div>
+  )
+}

--- a/src/routes/_authenticated/history/index.tsx
+++ b/src/routes/_authenticated/history/index.tsx
@@ -1,0 +1,130 @@
+import { useRef } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { useAuth } from '@/lib/auth'
+import { useWorkoutLogsSummary } from '@/hooks/use-workout-logs'
+import { WorkoutHistoryCard } from '@/components/history/workout-history-card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export const Route = createFileRoute('/_authenticated/history/')({
+  component: HistoryPage,
+})
+
+function HistoryListSkeleton() {
+  return (
+    <div className="space-y-0">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div
+          key={i}
+          className={`flex items-center justify-between px-4 py-3 ${
+            i % 2 === 0 ? 'bg-surface-iron' : 'bg-surface-charcoal'
+          }`}
+        >
+          <div className="flex flex-col gap-1.5 flex-1">
+            <Skeleton className="h-4 w-32 rounded-none bg-surface-steel" />
+            <Skeleton className="h-3 w-48 rounded-none bg-surface-steel" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-12 rounded-none bg-surface-steel" />
+            <Skeleton className="h-5 w-14 rounded-none bg-surface-steel" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function HistoryPage() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const userId = user?.id ?? ''
+
+  const { data: summaries = [], isLoading, isError } = useWorkoutLogsSummary(userId)
+
+  // Filter to only completed workouts
+  const completedSummaries = summaries.filter((s) => !!s.log.completedAt)
+
+  const parentRef = useRef<HTMLDivElement>(null)
+  const rowVirtualizer = useVirtualizer({
+    count: completedSummaries.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 72,
+    overscan: 5,
+  })
+
+  const handleCardClick = (workoutId: string) => {
+    navigate({ to: '/history/$workoutId', params: { workoutId } })
+  }
+
+  return (
+    <div className="flex min-h-[100dvh] flex-col bg-surface-anvil">
+      {/* Header */}
+      <div className="px-4 pt-6 pb-4">
+        <h1 className="font-display text-xl font-medium uppercase tracking-widest text-bone-white">
+          TRACKER
+        </h1>
+      </div>
+
+      {/* Content */}
+      {isLoading ? (
+        <HistoryListSkeleton />
+      ) : isError ? (
+        <div className="flex flex-col items-center justify-center px-4 py-16">
+          <span className="material-symbols-outlined mb-3 text-4xl text-warning-flare">
+            cloud_off
+          </span>
+          <p className="font-display text-sm uppercase tracking-widest text-warning-flare">
+            FAILED TO LOAD HISTORY
+          </p>
+          <p className="mt-2 text-xs text-warm-ash">Check your connection and try again.</p>
+        </div>
+      ) : completedSummaries.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center text-warm-ash/40">
+          <span
+            className="material-symbols-outlined text-5xl"
+            style={{ fontVariationSettings: "'FILL' 0, 'wght' 300, 'GRAD' 0, 'opsz' 48" }}
+          >
+            history
+          </span>
+          <p className="font-display text-sm uppercase tracking-widest text-warm-ash">
+            NO SESSIONS LOGGED
+          </p>
+          <p className="text-xs uppercase tracking-wider">COMPLETE A WORKOUT TO SEE IT HERE</p>
+        </div>
+      ) : (
+        <div ref={parentRef} className="flex-1 overflow-auto">
+          <div
+            style={{
+              height: `${rowVirtualizer.getTotalSize()}px`,
+              width: '100%',
+              position: 'relative',
+            }}
+          >
+            {rowVirtualizer.getVirtualItems().map((virtualItem) => {
+              const summary = completedSummaries[virtualItem.index]
+              return (
+                <div
+                  key={summary.log.id}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    height: `${virtualItem.size}px`,
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}
+                >
+                  <WorkoutHistoryCard
+                    summary={summary}
+                    index={virtualItem.index}
+                    onClick={() => handleCardClick(summary.log.id)}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add `/history` route with virtualized reverse-chronological workout list and empty state
- Add `/history/:workoutId` read-only detail view with full set-by-set data tables (SET / ACTUAL / STATUS columns), delete confirmation dialog, and program context display
- Add TRACKER tab to bottom navigation (order: FORGE > TRACKER > LIBRARY > PROFILE)
- Extend `DataAdapter` with `WorkoutLogSummary` type and `getWorkoutLogsSummary` (nested PostgREST query, no migrations)
- Add `useWorkoutLogsSummary` TanStack Query hook
- Enhance `ExerciseHistoryList` with horizontal volume load bars (`ember` fill on `surface-container-highest` track) and set-by-set session comparison
- Install `@tanstack/react-virtual` for virtualized list scrolling

## Test plan

- [ ] Navigate to TRACKER tab -- history list renders with virtualized scroll
- [ ] Empty state displays when no workouts logged
- [ ] Tap a workout card -- detail view loads with correct date, duration, volume totals
- [ ] Workout detail shows data tables with ALL-CAPS headers and status badges
- [ ] Delete button opens confirmation dialog; confirm deletes and redirects to `/history`
- [ ] Exercise detail HISTORY tab shows set-by-set rows with horizontal volume bars
- [ ] Volume bars scale correctly relative to max volume session
- [ ] `bunx tsc --noEmit` passes with zero errors
- [ ] `bun run build` succeeds