### PR TITLE
feat: program builder -- drag-and-drop UI, mobile editor, preview (Step 12)

### DIFF
--- a/src/components/program-builder/__tests__/builder-state.test.ts
+++ b/src/components/program-builder/__tests__/builder-state.test.ts
@@ -1,0 +1,845 @@
+import { describe, it, expect } from 'vitest'
+import type { ProgramFull } from '@/lib/data-adapter'
+import type { DayOfWeek } from '../constants'
+import {
+  createEmptyDraft,
+  addBlock,
+  removeBlock,
+  reorderBlocks,
+  addWeekToBlock,
+  removeWeekFromBlock,
+  assignSession,
+  removeSession,
+  copyWeek,
+  validateDraft,
+  buildSavePayload,
+  hydrateDraft,
+} from '../builder-state'
+import type { ProgramDraft, BlockDraft, WeekDraft, SessionDraft } from '../builder-state'
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+let counter = 0
+function nextId(): string {
+  counter += 1
+  return `test-id-${counter}`
+}
+
+function makeSession(overrides?: Partial<SessionDraft>): SessionDraft {
+  return {
+    clientId: nextId(),
+    dayOfWeek: 1,
+    dayLabel: 'Monday',
+    sessionType: 'STRENGTH',
+    sessionTemplateId: 'tpl-1',
+    templateName: 'Upper Body',
+    ...overrides,
+  }
+}
+
+function makeWeek(overrides?: Partial<WeekDraft>): WeekDraft {
+  return {
+    clientId: nextId(),
+    weekNumber: 1,
+    sessions: [],
+    ...overrides,
+  }
+}
+
+function makeBlock(overrides?: Partial<BlockDraft>): BlockDraft {
+  return {
+    clientId: nextId(),
+    name: 'Block 1',
+    ordinal: 1,
+    blockType: 'ACCUMULATION',
+    weeks: [makeWeek()],
+    ...overrides,
+  }
+}
+
+function makeProgramDraft(overrides?: Partial<ProgramDraft>): ProgramDraft {
+  return {
+    name: 'Test Program',
+    description: 'A test program',
+    source: 'CUSTOM',
+    blocks: [makeBlock()],
+    ...overrides,
+  }
+}
+
+function makeProgramFull(): ProgramFull {
+  return {
+    program: {
+      id: 'prog-db-1',
+      createdAt: '2025-06-01T00:00:00Z',
+      updatedAt: '2025-06-15T00:00:00Z',
+      userId: 'user-1',
+      name: 'Saved Program',
+      description: 'Persisted program',
+      source: 'CUSTOM',
+      durationWeeks: 2,
+      isPublic: false,
+      createdBy: 'user-1',
+    },
+    blocks: [
+      {
+        id: 'block-db-1',
+        programId: 'prog-db-1',
+        name: 'Accumulation',
+        ordinal: 1,
+        durationWeeks: 2,
+        blockType: 'ACCUMULATION',
+      },
+    ],
+    blockWeeks: [
+      { id: 'bw-db-1', blockId: 'block-db-1', weekNumber: 1 },
+      { id: 'bw-db-2', blockId: 'block-db-1', weekNumber: 2 },
+    ],
+    scheduledSessions: [
+      {
+        id: 'ss-db-1',
+        blockWeekId: 'bw-db-1',
+        dayOfWeek: 1,
+        dayLabel: 'Monday',
+        sessionType: 'STRENGTH',
+        sessionTemplateId: 'tpl-db-1',
+      },
+      {
+        id: 'ss-db-2',
+        blockWeekId: 'bw-db-2',
+        dayOfWeek: 3,
+        dayLabel: 'Wednesday',
+        sessionType: 'CONDITIONING',
+        sessionTemplateId: 'tpl-db-2',
+      },
+    ],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// createEmptyDraft
+// ---------------------------------------------------------------------------
+
+describe('createEmptyDraft', () => {
+  it('returns a draft with one block containing one week and empty sessions', () => {
+    const draft = createEmptyDraft()
+    expect(draft.blocks).toHaveLength(1)
+    expect(draft.blocks[0].weeks).toHaveLength(1)
+    expect(draft.blocks[0].weeks[0].sessions).toEqual([])
+  })
+
+  it('sets block ordinal to 1 and weekNumber to 1', () => {
+    const draft = createEmptyDraft()
+    expect(draft.blocks[0].ordinal).toBe(1)
+    expect(draft.blocks[0].weeks[0].weekNumber).toBe(1)
+  })
+
+  it('sets blockType to ACCUMULATION', () => {
+    const draft = createEmptyDraft()
+    expect(draft.blocks[0].blockType).toBe('ACCUMULATION')
+  })
+
+  it('has empty name, empty description, and source CUSTOM', () => {
+    const draft = createEmptyDraft()
+    expect(draft.name).toBe('')
+    expect(draft.description).toBe('')
+    expect(draft.source).toBe('CUSTOM')
+  })
+
+  it('generates unique clientIds for block and week', () => {
+    const draft = createEmptyDraft()
+    expect(draft.blocks[0].clientId).toBeTruthy()
+    expect(draft.blocks[0].weeks[0].clientId).toBeTruthy()
+    expect(draft.blocks[0].clientId).not.toBe(draft.blocks[0].weeks[0].clientId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// addBlock
+// ---------------------------------------------------------------------------
+
+describe('addBlock', () => {
+  it('adds a block with the next sequential ordinal', () => {
+    const draft = makeProgramDraft()
+    const result = addBlock(draft, 'INTENSIFICATION')
+    expect(result.blocks).toHaveLength(2)
+    expect(result.blocks[1].ordinal).toBe(2)
+    expect(result.blocks[1].blockType).toBe('INTENSIFICATION')
+  })
+
+  it('new block has one empty week with weekNumber 1', () => {
+    const draft = makeProgramDraft()
+    const result = addBlock(draft, 'DELOAD')
+    const newBlock = result.blocks[1]
+    expect(newBlock.weeks).toHaveLength(1)
+    expect(newBlock.weeks[0].weekNumber).toBe(1)
+    expect(newBlock.weeks[0].sessions).toEqual([])
+  })
+
+  it('does not mutate the input draft', () => {
+    const draft = makeProgramDraft()
+    const originalLength = draft.blocks.length
+    addBlock(draft, 'REALIZATION')
+    expect(draft.blocks.length).toBe(originalLength)
+  })
+
+  it('assigns a unique clientId to the new block', () => {
+    const draft = makeProgramDraft()
+    const result = addBlock(draft, 'TEST')
+    const existingIds = draft.blocks.map((b) => b.clientId)
+    expect(existingIds).not.toContain(result.blocks[1].clientId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// removeBlock
+// ---------------------------------------------------------------------------
+
+describe('removeBlock', () => {
+  it('removes the target block by clientId', () => {
+    const block1 = makeBlock({ ordinal: 1 })
+    const block2 = makeBlock({ ordinal: 2 })
+    const draft = makeProgramDraft({ blocks: [block1, block2] })
+
+    const result = removeBlock(draft, block1.clientId)
+    expect(result.blocks).toHaveLength(1)
+    expect(result.blocks[0].clientId).toBe(block2.clientId)
+  })
+
+  it('renumbers remaining block ordinals sequentially starting from 1', () => {
+    const block1 = makeBlock({ ordinal: 1 })
+    const block2 = makeBlock({ ordinal: 2 })
+    const block3 = makeBlock({ ordinal: 3 })
+    const draft = makeProgramDraft({ blocks: [block1, block2, block3] })
+
+    const result = removeBlock(draft, block2.clientId)
+    expect(result.blocks[0].ordinal).toBe(1)
+    expect(result.blocks[1].ordinal).toBe(2)
+  })
+
+  it('returns unchanged draft if clientId not found', () => {
+    const draft = makeProgramDraft()
+    const result = removeBlock(draft, 'nonexistent-id')
+    expect(result.blocks).toHaveLength(draft.blocks.length)
+    expect(result.blocks[0].clientId).toBe(draft.blocks[0].clientId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// reorderBlocks
+// ---------------------------------------------------------------------------
+
+describe('reorderBlocks', () => {
+  it('swaps block positions by index', () => {
+    const block1 = makeBlock({ ordinal: 1, name: 'First' })
+    const block2 = makeBlock({ ordinal: 2, name: 'Second' })
+    const block3 = makeBlock({ ordinal: 3, name: 'Third' })
+    const draft = makeProgramDraft({ blocks: [block1, block2, block3] })
+
+    const result = reorderBlocks(draft, 0, 2)
+    expect(result.blocks[0].name).toBe('Second')
+    expect(result.blocks[1].name).toBe('Third')
+    expect(result.blocks[2].name).toBe('First')
+  })
+
+  it('renumbers ordinals after reorder (ordinal === position + 1)', () => {
+    const block1 = makeBlock({ ordinal: 1, name: 'A' })
+    const block2 = makeBlock({ ordinal: 2, name: 'B' })
+    const draft = makeProgramDraft({ blocks: [block1, block2] })
+
+    const result = reorderBlocks(draft, 1, 0)
+    expect(result.blocks[0].ordinal).toBe(1)
+    expect(result.blocks[1].ordinal).toBe(2)
+    expect(result.blocks[0].name).toBe('B')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// addWeekToBlock
+// ---------------------------------------------------------------------------
+
+describe('addWeekToBlock', () => {
+  it('adds a week with the next sequential weekNumber to the target block', () => {
+    const block = makeBlock({ weeks: [makeWeek({ weekNumber: 1 })] })
+    const draft = makeProgramDraft({ blocks: [block] })
+
+    const result = addWeekToBlock(draft, block.clientId)
+    const targetBlock = result.blocks[0]
+    expect(targetBlock.weeks).toHaveLength(2)
+    expect(targetBlock.weeks[1].weekNumber).toBe(2)
+  })
+
+  it('does not modify other blocks', () => {
+    const block1 = makeBlock({ ordinal: 1 })
+    const block2 = makeBlock({ ordinal: 2 })
+    const draft = makeProgramDraft({ blocks: [block1, block2] })
+
+    const result = addWeekToBlock(draft, block1.clientId)
+    expect(result.blocks[0].weeks).toHaveLength(2)
+    expect(result.blocks[1].weeks).toHaveLength(1)
+  })
+
+  it('returns draft unchanged if blockClientId not found', () => {
+    const draft = makeProgramDraft()
+    const result = addWeekToBlock(draft, 'nonexistent-block')
+    expect(result.blocks[0].weeks).toHaveLength(draft.blocks[0].weeks.length)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// removeWeekFromBlock
+// ---------------------------------------------------------------------------
+
+describe('removeWeekFromBlock', () => {
+  it('removes the target week and renumbers remaining weeks sequentially', () => {
+    const week1 = makeWeek({ weekNumber: 1 })
+    const week2 = makeWeek({ weekNumber: 2 })
+    const week3 = makeWeek({ weekNumber: 3 })
+    const block = makeBlock({ weeks: [week1, week2, week3] })
+    const draft = makeProgramDraft({ blocks: [block] })
+
+    const result = removeWeekFromBlock(draft, block.clientId, week2.clientId)
+    expect(result.blocks[0].weeks).toHaveLength(2)
+    expect(result.blocks[0].weeks[0].weekNumber).toBe(1)
+    expect(result.blocks[0].weeks[1].weekNumber).toBe(2)
+  })
+
+  it('does not remove the last remaining week (guard)', () => {
+    const week = makeWeek()
+    const block = makeBlock({ weeks: [week] })
+    const draft = makeProgramDraft({ blocks: [block] })
+
+    const result = removeWeekFromBlock(draft, block.clientId, week.clientId)
+    expect(result.blocks[0].weeks).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// assignSession
+// ---------------------------------------------------------------------------
+
+describe('assignSession', () => {
+  it('assigns a session to the correct week and day', () => {
+    const week = makeWeek()
+    const block = makeBlock({ weeks: [week] })
+    const draft = makeProgramDraft({ blocks: [block] })
+
+    const result = assignSession(
+      draft,
+      week.clientId,
+      3 as DayOfWeek,
+      'tpl-99',
+      'Wednesday Workout',
+      'CONDITIONING',
+    )
+
+    const sessions = result.blocks[0].weeks[0].sessions
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].dayOfWeek).toBe(3)
+    expect(sessions[0].dayLabel).toBe('Wednesday')
+    expect(sessions[0].sessionTemplateId).toBe('tpl-99')
+    expect(sessions[0].templateName).toBe('Wednesday Workout')
+    expect(sessions[0].sessionType).toBe('CONDITIONING')
+  })
+
+  it('replaces an existing session on the same day (no duplicates)', () => {
+    const existingSession = makeSession({ dayOfWeek: 1, templateName: 'Old' })
+    const week = makeWeek({ sessions: [existingSession] })
+    const block = makeBlock({ weeks: [week] })
+    const draft = makeProgramDraft({ blocks: [block] })
+
+    const result = assignSession(
+      draft,
+      week.clientId,
+      1 as DayOfWeek,
+      'tpl-new',
+      'New Monday',
+      'STRENGTH',
+    )
+
+    const sessions = result.blocks[0].weeks[0].sessions
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].templateName).toBe('New Monday')
+    expect(sessions[0].sessionTemplateId).toBe('tpl-new')
+  })
+
+  it('creates a session entry with the given templateId, templateName, sessionType', () => {
+    const week = makeWeek()
+    const block = makeBlock({ weeks: [week] })
+    const draft = makeProgramDraft({ blocks: [block] })
+
+    const result = assignSession(
+      draft,
+      week.clientId,
+      5 as DayOfWeek,
+      'tpl-friday',
+      'Friday Power',
+      'MIXED',
+    )
+
+    const session = result.blocks[0].weeks[0].sessions[0]
+    expect(session.sessionTemplateId).toBe('tpl-friday')
+    expect(session.templateName).toBe('Friday Power')
+    expect(session.sessionType).toBe('MIXED')
+    expect(session.dayOfWeek).toBe(5)
+    expect(session.dayLabel).toBe('Friday')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// removeSession
+// ---------------------------------------------------------------------------
+
+describe('removeSession', () => {
+  it('removes the target session by clientId from the correct week', () => {
+    const session1 = makeSession({ dayOfWeek: 1 })
+    const session2 = makeSession({ dayOfWeek: 3 })
+    const week = makeWeek({ sessions: [session1, session2] })
+    const block = makeBlock({ weeks: [week] })
+    const draft = makeProgramDraft({ blocks: [block] })
+
+    const result = removeSession(draft, week.clientId, session1.clientId)
+    const sessions = result.blocks[0].weeks[0].sessions
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].clientId).toBe(session2.clientId)
+  })
+
+  it('only modifies the target week (other weeks untouched)', () => {
+    const sessionA = makeSession({ dayOfWeek: 1 })
+    const sessionB = makeSession({ dayOfWeek: 2 })
+    const week1 = makeWeek({ weekNumber: 1, sessions: [sessionA] })
+    const week2 = makeWeek({ weekNumber: 2, sessions: [sessionB] })
+    const block = makeBlock({ weeks: [week1, week2] })
+    const draft = makeProgramDraft({ blocks: [block] })
+
+    const result = removeSession(draft, week1.clientId, sessionA.clientId)
+    expect(result.blocks[0].weeks[0].sessions).toHaveLength(0)
+    expect(result.blocks[0].weeks[1].sessions).toHaveLength(1)
+    expect(result.blocks[0].weeks[1].sessions[0].clientId).toBe(sessionB.clientId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// copyWeek
+// ---------------------------------------------------------------------------
+
+describe('copyWeek', () => {
+  it('copies all sessions from source to each target week with fresh clientIds', () => {
+    const session1 = makeSession({ dayOfWeek: 1, templateName: 'Mon' })
+    const session2 = makeSession({ dayOfWeek: 3, templateName: 'Wed' })
+    const sourceWeek = makeWeek({ weekNumber: 1, sessions: [session1, session2] })
+    const targetWeek1 = makeWeek({ weekNumber: 2, sessions: [] })
+    const targetWeek2 = makeWeek({ weekNumber: 3, sessions: [] })
+    const block = makeBlock({ weeks: [sourceWeek, targetWeek1, targetWeek2] })
+    const draft = makeProgramDraft({ blocks: [block] })
+
+    const result = copyWeek(draft, sourceWeek.clientId, [
+      targetWeek1.clientId,
+      targetWeek2.clientId,
+    ])
+
+    // Target weeks should have copied sessions
+    const target1Sessions = result.blocks[0].weeks[1].sessions
+    const target2Sessions = result.blocks[0].weeks[2].sessions
+    expect(target1Sessions).toHaveLength(2)
+    expect(target2Sessions).toHaveLength(2)
+
+    // Copied sessions should have fresh clientIds (not matching source)
+    const sourceIds = [session1.clientId, session2.clientId]
+    for (const s of target1Sessions) {
+      expect(sourceIds).not.toContain(s.clientId)
+    }
+    for (const s of target2Sessions) {
+      expect(sourceIds).not.toContain(s.clientId)
+    }
+
+    // But content should match
+    expect(target1Sessions[0].templateName).toBe('Mon')
+    expect(target1Sessions[1].templateName).toBe('Wed')
+  })
+
+  it('is a no-op when source week has zero sessions', () => {
+    const emptySourceWeek = makeWeek({ weekNumber: 1, sessions: [] })
+    const targetWeek = makeWeek({ weekNumber: 2, sessions: [] })
+    const block = makeBlock({ weeks: [emptySourceWeek, targetWeek] })
+    const draft = makeProgramDraft({ blocks: [block] })
+
+    const result = copyWeek(draft, emptySourceWeek.clientId, [targetWeek.clientId])
+    // Should return the same reference (no-op)
+    expect(result).toBe(draft)
+    expect(result.blocks[0].weeks[1].sessions).toHaveLength(0)
+  })
+
+  it('copies to multiple target weeks simultaneously', () => {
+    const session = makeSession({ dayOfWeek: 5, templateName: 'Friday' })
+    const source = makeWeek({ weekNumber: 1, sessions: [session] })
+    const target1 = makeWeek({ weekNumber: 2 })
+    const target2 = makeWeek({ weekNumber: 3 })
+    const target3 = makeWeek({ weekNumber: 4 })
+    const block = makeBlock({ weeks: [source, target1, target2, target3] })
+    const draft = makeProgramDraft({ blocks: [block] })
+
+    const result = copyWeek(draft, source.clientId, [
+      target1.clientId,
+      target2.clientId,
+      target3.clientId,
+    ])
+
+    expect(result.blocks[0].weeks[1].sessions).toHaveLength(1)
+    expect(result.blocks[0].weeks[2].sessions).toHaveLength(1)
+    expect(result.blocks[0].weeks[3].sessions).toHaveLength(1)
+
+    // Each target should have a unique clientId for its copied session
+    const allCopiedIds = [
+      result.blocks[0].weeks[1].sessions[0].clientId,
+      result.blocks[0].weeks[2].sessions[0].clientId,
+      result.blocks[0].weeks[3].sessions[0].clientId,
+    ]
+    const uniqueIds = new Set(allCopiedIds)
+    expect(uniqueIds.size).toBe(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateDraft
+// ---------------------------------------------------------------------------
+
+describe('validateDraft', () => {
+  it('returns empty array for a fully valid draft', () => {
+    const draft = makeProgramDraft({ name: 'Valid Program' })
+    const errors = validateDraft(draft)
+    expect(errors).toEqual([])
+  })
+
+  it('returns error for empty name', () => {
+    const draft = makeProgramDraft({ name: '' })
+    const errors = validateDraft(draft)
+    expect(errors).toContain('Program name is required')
+  })
+
+  it('returns error for whitespace-only name', () => {
+    const draft = makeProgramDraft({ name: '   ' })
+    const errors = validateDraft(draft)
+    expect(errors).toContain('Program name is required')
+  })
+
+  it('returns error for empty blocks array', () => {
+    const draft = makeProgramDraft({ name: 'Has Name', blocks: [] })
+    const errors = validateDraft(draft)
+    expect(errors).toContain('At least one block is required')
+  })
+
+  it('returns error for non-sequential ordinals', () => {
+    const block1 = makeBlock({ ordinal: 1 })
+    const block2 = makeBlock({ ordinal: 3 }) // gap: should be 2
+    const draft = makeProgramDraft({ name: 'Test', blocks: [block1, block2] })
+    const errors = validateDraft(draft)
+    expect(errors.some((e) => e.includes('not sequential'))).toBe(true)
+  })
+
+  it('returns error for a block with zero weeks', () => {
+    const block = makeBlock({ weeks: [] })
+    const draft = makeProgramDraft({ name: 'Test', blocks: [block] })
+    const errors = validateDraft(draft)
+    expect(errors.some((e) => e.includes('at least one week'))).toBe(true)
+  })
+
+  it('returns error for name over 200 characters', () => {
+    const draft = makeProgramDraft({ name: 'X'.repeat(201) })
+    const errors = validateDraft(draft)
+    expect(errors).toContain('Program name must be 200 characters or less')
+  })
+
+  it('accepts name of exactly 200 characters', () => {
+    const draft = makeProgramDraft({ name: 'X'.repeat(200) })
+    const errors = validateDraft(draft)
+    expect(errors).not.toContain('Program name must be 200 characters or less')
+  })
+
+  it('returns error for block name over 200 characters', () => {
+    const block = makeBlock({ name: 'B'.repeat(201) })
+    const draft = makeProgramDraft({ name: 'Valid', blocks: [block] })
+    const errors = validateDraft(draft)
+    expect(errors).toContain('Block name must be 200 characters or less')
+  })
+
+  it('returns error for empty block name', () => {
+    const block = makeBlock({ name: '' })
+    const draft = makeProgramDraft({ name: 'Valid', blocks: [block] })
+    const errors = validateDraft(draft)
+    expect(errors).toContain('Block name is required')
+  })
+
+  it('returns error for whitespace-only block name', () => {
+    const block = makeBlock({ name: '   ' })
+    const draft = makeProgramDraft({ name: 'Valid', blocks: [block] })
+    const errors = validateDraft(draft)
+    expect(errors).toContain('Block name is required')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildSavePayload -- create mode
+// ---------------------------------------------------------------------------
+
+describe('buildSavePayload -- create mode', () => {
+  it('returns mode: create when draft has no id', () => {
+    const draft = makeProgramDraft({ name: 'New Program' })
+    const payload = buildSavePayload(draft, 'user-1')
+    expect(payload.mode).toBe('create')
+  })
+
+  it('program payload does NOT include id', () => {
+    const draft = makeProgramDraft({ name: 'New Program' })
+    const payload = buildSavePayload(draft, 'user-1')
+    expect(payload.mode).toBe('create')
+    if (payload.mode === 'create') {
+      expect('id' in payload.program).toBe(false)
+    }
+  })
+
+  it('block payloads have durationWeeks computed from weeks.length', () => {
+    const week1 = makeWeek({ weekNumber: 1 })
+    const week2 = makeWeek({ weekNumber: 2 })
+    const block = makeBlock({ weeks: [week1, week2] })
+    const draft = makeProgramDraft({ name: 'Test', blocks: [block] })
+
+    const payload = buildSavePayload(draft, 'user-1')
+    expect(payload.mode).toBe('create')
+    if (payload.mode === 'create') {
+      expect(payload.blocks[0].block.durationWeeks).toBe(2)
+    }
+  })
+
+  it('program durationWeeks is the sum of all block week counts', () => {
+    const block1 = makeBlock({
+      ordinal: 1,
+      weeks: [makeWeek({ weekNumber: 1 }), makeWeek({ weekNumber: 2 })],
+    })
+    const block2 = makeBlock({
+      ordinal: 2,
+      weeks: [
+        makeWeek({ weekNumber: 1 }),
+        makeWeek({ weekNumber: 2 }),
+        makeWeek({ weekNumber: 3 }),
+      ],
+    })
+    const draft = makeProgramDraft({ name: 'Multi-Block', blocks: [block1, block2] })
+
+    const payload = buildSavePayload(draft, 'user-1')
+    expect(payload.program.durationWeeks).toBe(5)
+  })
+
+  it('trims program name and description', () => {
+    const draft = makeProgramDraft({ name: '  Spaced Name  ', description: '  Desc  ' })
+    const payload = buildSavePayload(draft, 'user-1')
+    expect(payload.program.name).toBe('Spaced Name')
+    if (payload.mode === 'create') {
+      expect(payload.program.description).toBe('Desc')
+    }
+  })
+
+  it('sets description to undefined when empty after trim', () => {
+    const draft = makeProgramDraft({ name: 'Test', description: '   ' })
+    const payload = buildSavePayload(draft, 'user-1')
+    expect(payload.program.description).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildSavePayload -- update mode
+// ---------------------------------------------------------------------------
+
+describe('buildSavePayload -- update mode', () => {
+  function makeEditDraft(): ProgramDraft {
+    return {
+      id: 'prog-existing-1',
+      name: 'Updated Program',
+      description: 'Updated desc',
+      source: 'CUSTOM',
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-15T00:00:00Z',
+      blocks: [
+        {
+          clientId: 'block-existing-1',
+          name: 'Phase 1',
+          ordinal: 1,
+          blockType: 'ACCUMULATION',
+          weeks: [
+            {
+              clientId: 'week-existing-1',
+              weekNumber: 1,
+              sessions: [
+                {
+                  clientId: 'session-existing-1',
+                  dayOfWeek: 1,
+                  dayLabel: 'Monday',
+                  sessionType: 'STRENGTH',
+                  sessionTemplateId: 'tpl-1',
+                  templateName: 'Heavy Squat',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+  }
+
+  it('returns mode: update when draft has an id', () => {
+    const draft = makeEditDraft()
+    const payload = buildSavePayload(draft, 'user-1')
+    expect(payload.mode).toBe('update')
+  })
+
+  it('program payload includes the original id', () => {
+    const draft = makeEditDraft()
+    const payload = buildSavePayload(draft, 'user-1')
+    if (payload.mode === 'update') {
+      expect(payload.program.id).toBe('prog-existing-1')
+    }
+  })
+
+  it('block payloads include the original clientId as id (DB ID preservation)', () => {
+    const draft = makeEditDraft()
+    const payload = buildSavePayload(draft, 'user-1')
+    if (payload.mode === 'update') {
+      expect(payload.blocks[0].block.id).toBe('block-existing-1')
+    }
+  })
+
+  it('week payloads include the original clientId as id', () => {
+    const draft = makeEditDraft()
+    const payload = buildSavePayload(draft, 'user-1')
+    if (payload.mode === 'update') {
+      expect(payload.blocks[0].weeks[0].week.id).toBe('week-existing-1')
+    }
+  })
+
+  it('createdAt in program payload equals draft.createdAt', () => {
+    const draft = makeEditDraft()
+    const payload = buildSavePayload(draft, 'user-1')
+    if (payload.mode === 'update') {
+      expect(payload.program.createdAt).toBe('2025-01-01T00:00:00Z')
+    }
+  })
+
+  it('updatedAt in program payload is a fresh ISO timestamp (not draft.createdAt)', () => {
+    const draft = makeEditDraft()
+    const payload = buildSavePayload(draft, 'user-1')
+    if (payload.mode === 'update') {
+      expect(payload.program.updatedAt).not.toBe('2025-01-01T00:00:00Z')
+      // Verify it is a valid ISO timestamp
+      const parsed = Date.parse(payload.program.updatedAt)
+      expect(isNaN(parsed)).toBe(false)
+    }
+  })
+
+  it('computes durationWeeks correctly in update mode', () => {
+    const draft = makeEditDraft()
+    const payload = buildSavePayload(draft, 'user-1')
+    // 1 block with 1 week = 1
+    expect(payload.program.durationWeeks).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// hydrateDraft
+// ---------------------------------------------------------------------------
+
+describe('hydrateDraft', () => {
+  it('preserves original DB IDs as clientIds', () => {
+    const full = makeProgramFull()
+    const draft = hydrateDraft(full)
+
+    expect(draft.blocks[0].clientId).toBe('block-db-1')
+    expect(draft.blocks[0].weeks[0].clientId).toBe('bw-db-1')
+    expect(draft.blocks[0].weeks[1].clientId).toBe('bw-db-2')
+  })
+
+  it('preserves createdAt and updatedAt on the returned draft', () => {
+    const full = makeProgramFull()
+    const draft = hydrateDraft(full)
+
+    expect(draft.createdAt).toBe('2025-06-01T00:00:00Z')
+    expect(draft.updatedAt).toBe('2025-06-15T00:00:00Z')
+  })
+
+  it('preserves program id', () => {
+    const full = makeProgramFull()
+    const draft = hydrateDraft(full)
+    expect(draft.id).toBe('prog-db-1')
+  })
+
+  it('sorts blocks by ordinal', () => {
+    const full = makeProgramFull()
+    // Add a second block with ordinal 2 but place it first in the array
+    full.blocks = [
+      {
+        id: 'block-db-2',
+        programId: 'prog-db-1',
+        name: 'Intensification',
+        ordinal: 2,
+        durationWeeks: 1,
+        blockType: 'INTENSIFICATION',
+      },
+      full.blocks[0], // ordinal 1
+    ]
+    full.blockWeeks.push({ id: 'bw-db-3', blockId: 'block-db-2', weekNumber: 1 })
+
+    const draft = hydrateDraft(full)
+    expect(draft.blocks[0].ordinal).toBe(1)
+    expect(draft.blocks[0].clientId).toBe('block-db-1')
+    expect(draft.blocks[1].ordinal).toBe(2)
+    expect(draft.blocks[1].clientId).toBe('block-db-2')
+  })
+
+  it('sorts weeks by weekNumber', () => {
+    const full = makeProgramFull()
+    // Reverse the blockWeeks order (week 2 before week 1)
+    full.blockWeeks = [full.blockWeeks[1], full.blockWeeks[0]]
+
+    const draft = hydrateDraft(full)
+    expect(draft.blocks[0].weeks[0].weekNumber).toBe(1)
+    expect(draft.blocks[0].weeks[1].weekNumber).toBe(2)
+  })
+
+  it('round-trip: all session data preserved (dayOfWeek, templateId, sessionType)', () => {
+    const full = makeProgramFull()
+    const draft = hydrateDraft(full)
+
+    // Week 1 session
+    const s1 = draft.blocks[0].weeks[0].sessions[0]
+    expect(s1.dayOfWeek).toBe(1)
+    expect(s1.dayLabel).toBe('Monday')
+    expect(s1.sessionType).toBe('STRENGTH')
+    expect(s1.sessionTemplateId).toBe('tpl-db-1')
+    expect(s1.clientId).toBe('ss-db-1')
+
+    // Week 2 session
+    const s2 = draft.blocks[0].weeks[1].sessions[0]
+    expect(s2.dayOfWeek).toBe(3)
+    expect(s2.dayLabel).toBe('Wednesday')
+    expect(s2.sessionType).toBe('CONDITIONING')
+    expect(s2.sessionTemplateId).toBe('tpl-db-2')
+    expect(s2.clientId).toBe('ss-db-2')
+  })
+
+  it('hydrates name, description, and source from the program', () => {
+    const full = makeProgramFull()
+    const draft = hydrateDraft(full)
+
+    expect(draft.name).toBe('Saved Program')
+    expect(draft.description).toBe('Persisted program')
+    expect(draft.source).toBe('CUSTOM')
+  })
+
+  it('sets description to empty string when program description is undefined', () => {
+    const full = makeProgramFull()
+    full.program = { ...full.program, description: undefined }
+    const draft = hydrateDraft(full)
+    expect(draft.description).toBe('')
+  })
+})

--- a/src/components/program-builder/block-editor.tsx
+++ b/src/components/program-builder/block-editor.tsx
@@ -7,18 +7,8 @@ import { WeekGrid } from './week-grid'
 import { removeBlock, addWeekToBlock } from './builder-state'
 import type { BlockDraft, ProgramDraft } from './builder-state'
 import type { BlockType } from '@/domain/types'
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const BLOCK_TYPES: Array<{ value: BlockType; label: string }> = [
-  { value: 'ACCUMULATION', label: 'ACCUMULATION' },
-  { value: 'INTENSIFICATION', label: 'INTENSIFICATION' },
-  { value: 'REALIZATION', label: 'REALIZATION' },
-  { value: 'DELOAD', label: 'DELOAD' },
-  { value: 'TEST', label: 'TEST' },
-]
+import { BLOCK_TYPES } from './constants'
+import type { DayOfWeek } from './constants'
 
 // ---------------------------------------------------------------------------
 // BlockEditor
@@ -28,7 +18,7 @@ interface BlockEditorProps {
   block: BlockDraft
   draft: ProgramDraft
   onUpdate: (draft: ProgramDraft) => void
-  onPickSession: (weekClientId: string, dayOfWeek: number) => void
+  onPickSession: (weekClientId: string, dayOfWeek: DayOfWeek) => void
   onCopyWeek?: (sourceWeekClientId: string) => void
 }
 
@@ -58,7 +48,6 @@ export function BlockEditor({
     opacity: isDragging ? 0.5 : 1,
   }
 
-  // Handlers
   const handleNameChange = useCallback(
     (newName: string) => {
       onUpdate({
@@ -111,12 +100,10 @@ export function BlockEditor({
 
   return (
     <div ref={setNodeRef} style={style} {...attributes} className="bg-surface-iron">
-      {/* Header */}
       <div
         className="flex min-h-12 cursor-pointer items-center gap-2 px-3 py-2"
         onClick={handleHeaderClick}
       >
-        {/* Drag handle */}
         <button
           ref={setActivatorNodeRef}
           {...listeners}
@@ -128,7 +115,6 @@ export function BlockEditor({
           <Icon name="drag_indicator" size={20} />
         </button>
 
-        {/* Block name (inline editable) */}
         {isEditingName ? (
           <input
             type="text"
@@ -155,17 +141,14 @@ export function BlockEditor({
           </button>
         )}
 
-        {/* Block type badge */}
         <span className="bg-surface-steel px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-bone-white">
           {block.blockType}
         </span>
 
-        {/* Duration label */}
         <span className="text-[10px] font-medium uppercase tracking-wider text-warm-ash/60">
-          {block.durationWeeks} {block.durationWeeks === 1 ? 'WEEK' : 'WEEKS'}
+          {block.weeks.length} {block.weeks.length === 1 ? 'WEEK' : 'WEEKS'}
         </span>
 
-        {/* Delete button */}
         <button
           type="button"
           onClick={(e) => {
@@ -178,7 +161,6 @@ export function BlockEditor({
           <Icon name="delete" size={18} />
         </button>
 
-        {/* Expand/collapse indicator */}
         <Icon
           name={expanded ? 'expand_less' : 'expand_more'}
           size={18}
@@ -189,7 +171,6 @@ export function BlockEditor({
       {/* Expanded content */}
       {expanded && (
         <div className="flex flex-col gap-4 px-3 pb-4">
-          {/* Block type selector */}
           <div className="flex flex-wrap gap-1">
             {BLOCK_TYPES.map((bt) => (
               <button
@@ -207,7 +188,6 @@ export function BlockEditor({
             ))}
           </div>
 
-          {/* Week grids */}
           {block.weeks.map((week, weekIndex) => (
             <WeekGrid
               key={week.clientId}
@@ -221,7 +201,6 @@ export function BlockEditor({
             />
           ))}
 
-          {/* Add week button */}
           <Button
             type="button"
             variant="secondary"

--- a/src/components/program-builder/block-list.tsx
+++ b/src/components/program-builder/block-list.tsx
@@ -14,6 +14,7 @@ import { Icon } from '@/components/icon'
 import { BlockEditor } from './block-editor'
 import { addBlock, reorderBlocks } from './builder-state'
 import type { ProgramDraft } from './builder-state'
+import type { DayOfWeek } from './constants'
 
 // ---------------------------------------------------------------------------
 // Custom modifier: restrict drag to vertical axis
@@ -31,7 +32,7 @@ const restrictToVerticalAxis: Modifier = ({ transform }) => ({
 interface BlockListProps {
   draft: ProgramDraft
   onUpdate: (draft: ProgramDraft) => void
-  onPickSession: (weekClientId: string, dayOfWeek: number) => void
+  onPickSession: (weekClientId: string, dayOfWeek: DayOfWeek) => void
   onCopyWeek?: (sourceWeekClientId: string) => void
 }
 

--- a/src/components/program-builder/builder-state.ts
+++ b/src/components/program-builder/builder-state.ts
@@ -8,6 +8,8 @@ import type {
   ScheduledSession,
 } from '@/domain/types'
 import type { ProgramFull } from '@/lib/data-adapter'
+import { DAY_LABELS } from './constants'
+import type { DayOfWeek } from './constants'
 
 // ---------------------------------------------------------------------------
 // Draft types -- local builder state with client-side UUIDs
@@ -15,7 +17,7 @@ import type { ProgramFull } from '@/lib/data-adapter'
 
 export type SessionDraft = {
   clientId: string
-  dayOfWeek: number | null // 0-6 (Sun-Sat), null if unscheduled
+  dayOfWeek: DayOfWeek | null // 0-6 where 0=Sunday through 6=Saturday (JS convention); UI renders Mon-Sun order. null if unscheduled
   dayLabel: string
   sessionType: SessionType
   sessionTemplateId: string
@@ -32,7 +34,6 @@ export type BlockDraft = {
   clientId: string
   name: string
   ordinal: number
-  durationWeeks: number
   blockType: BlockType
   weeks: WeekDraft[]
 }
@@ -42,21 +43,9 @@ export type ProgramDraft = {
   name: string
   description: string
   source: ProgramSource
+  createdAt?: string // preserved from DB in edit mode
+  updatedAt?: string // preserved from DB in edit mode
   blocks: BlockDraft[]
-}
-
-// ---------------------------------------------------------------------------
-// Day-of-week labels
-// ---------------------------------------------------------------------------
-
-const DAY_LABELS: Record<number, string> = {
-  0: 'Sunday',
-  1: 'Monday',
-  2: 'Tuesday',
-  3: 'Wednesday',
-  4: 'Thursday',
-  5: 'Friday',
-  6: 'Saturday',
 }
 
 // ---------------------------------------------------------------------------
@@ -73,7 +62,6 @@ export function createEmptyDraft(): ProgramDraft {
         clientId: crypto.randomUUID(),
         name: 'Block 1',
         ordinal: 1,
-        durationWeeks: 1,
         blockType: 'ACCUMULATION',
         weeks: [
           {
@@ -97,7 +85,6 @@ export function addBlock(draft: ProgramDraft, blockType: BlockType): ProgramDraf
     clientId: crypto.randomUUID(),
     name: `Block ${ordinal}`,
     ordinal,
-    durationWeeks: 1,
     blockType,
     weeks: [
       {
@@ -143,7 +130,7 @@ export function addWeekToBlock(draft: ProgramDraft, blockClientId: string): Prog
         sessions: [],
       }
       const weeks = [...block.weeks, newWeek]
-      return { ...block, weeks, durationWeeks: weeks.length }
+      return { ...block, weeks }
     }),
   }
 }
@@ -162,7 +149,7 @@ export function removeWeekFromBlock(
       const weeks = block.weeks
         .filter((w) => w.clientId !== weekClientId)
         .map((w, i) => ({ ...w, weekNumber: i + 1 }))
-      return { ...block, weeks, durationWeeks: weeks.length }
+      return { ...block, weeks }
     }),
   }
 }
@@ -174,7 +161,7 @@ export function removeWeekFromBlock(
 export function assignSession(
   draft: ProgramDraft,
   weekClientId: string,
-  dayOfWeek: number,
+  dayOfWeek: DayOfWeek,
   templateId: string,
   templateName: string,
   sessionType: SessionType,
@@ -238,6 +225,7 @@ export function copyWeek(
     }
   }
 
+  // No-op: copying an empty week has no effect
   if (sourceSessions.length === 0) return draft
 
   const targetSet = new Set(targetWeekClientIds)
@@ -270,11 +258,23 @@ export function validateDraft(draft: ProgramDraft): string[] {
     errors.push('Program name is required')
   }
 
+  if (draft.name.trim().length > 200) {
+    errors.push('Program name must be 200 characters or less')
+  }
+
   if (draft.blocks.length === 0) {
     errors.push('At least one block is required')
   }
 
   for (const block of draft.blocks) {
+    if (block.name.trim().length === 0) {
+      errors.push('Block name is required')
+    }
+
+    if (block.name.trim().length > 200) {
+      errors.push('Block name must be 200 characters or less')
+    }
+
     if (block.weeks.length === 0) {
       errors.push(`Block "${block.name}" must have at least one week`)
     }
@@ -296,6 +296,69 @@ export function validateDraft(draft: ProgramDraft): string[] {
 // Build save payload
 // ---------------------------------------------------------------------------
 
+type SessionPayload = Omit<ScheduledSession, 'id' | 'blockWeekId'>
+
+type CreateBlockPayload = {
+  block: Omit<Block, 'id' | 'programId'>
+  weeks: Array<{
+    week: Omit<BlockWeek, 'id' | 'blockId'>
+    sessions: SessionPayload[]
+  }>
+}
+
+type UpdateBlockPayload = {
+  block: Omit<Block, 'programId'>
+  weeks: Array<{
+    week: Omit<BlockWeek, 'blockId'>
+    sessions: SessionPayload[]
+  }>
+}
+
+function buildSessionsPayload(sessions: SessionDraft[]): SessionPayload[] {
+  return sessions.map((session) => ({
+    dayOfWeek: session.dayOfWeek ?? undefined,
+    dayLabel: session.dayLabel,
+    sessionType: session.sessionType,
+    sessionTemplateId: session.sessionTemplateId,
+  }))
+}
+
+function buildCreateBlocksPayload(blocks: BlockDraft[]): CreateBlockPayload[] {
+  return blocks.map((block) => ({
+    block: {
+      name: block.name,
+      ordinal: block.ordinal,
+      durationWeeks: block.weeks.length,
+      blockType: block.blockType,
+    },
+    weeks: block.weeks.map((week) => ({
+      week: {
+        weekNumber: week.weekNumber,
+      },
+      sessions: buildSessionsPayload(week.sessions),
+    })),
+  }))
+}
+
+function buildUpdateBlocksPayload(blocks: BlockDraft[]): UpdateBlockPayload[] {
+  return blocks.map((block) => ({
+    block: {
+      id: block.clientId,
+      name: block.name,
+      ordinal: block.ordinal,
+      durationWeeks: block.weeks.length,
+      blockType: block.blockType,
+    },
+    weeks: block.weeks.map((week) => ({
+      week: {
+        id: week.clientId,
+        weekNumber: week.weekNumber,
+      },
+      sessions: buildSessionsPayload(week.sessions),
+    })),
+  }))
+}
+
 export function buildSavePayload(
   draft: ProgramDraft,
   userId: string,
@@ -303,49 +366,16 @@ export function buildSavePayload(
   | {
       mode: 'create'
       program: Omit<Program, 'id' | 'createdAt' | 'updatedAt'>
-      blocks: Array<{
-        block: Omit<Block, 'id' | 'programId'>
-        weeks: Array<{
-          week: Omit<BlockWeek, 'id' | 'blockId'>
-          sessions: Array<Omit<ScheduledSession, 'id' | 'blockWeekId'>>
-        }>
-      }>
+      blocks: CreateBlockPayload[]
     }
   | {
       mode: 'update'
       program: Program
-      blocks: Array<{
-        block: Omit<Block, 'programId'>
-        weeks: Array<{
-          week: Omit<BlockWeek, 'blockId'>
-          sessions: Array<Omit<ScheduledSession, 'id' | 'blockWeekId'>>
-        }>
-      }>
+      blocks: UpdateBlockPayload[]
     } {
-  const blocksPayload = draft.blocks.map((block) => ({
-    block: {
-      ...(draft.id ? { id: block.clientId } : {}),
-      name: block.name,
-      ordinal: block.ordinal,
-      durationWeeks: block.durationWeeks,
-      blockType: block.blockType,
-    },
-    weeks: block.weeks.map((week) => ({
-      week: {
-        ...(draft.id ? { id: week.clientId } : {}),
-        weekNumber: week.weekNumber,
-      },
-      sessions: week.sessions.map((session) => ({
-        dayOfWeek: session.dayOfWeek ?? undefined,
-        dayLabel: session.dayLabel,
-        sessionType: session.sessionType,
-        sessionTemplateId: session.sessionTemplateId,
-      })),
-    })),
-  }))
+  const totalDurationWeeks = draft.blocks.reduce((sum, b) => sum + b.weeks.length, 0)
 
   if (draft.id) {
-    // Update mode: program has full entity shape
     const now = new Date().toISOString()
     return {
       mode: 'update' as const,
@@ -355,23 +385,16 @@ export function buildSavePayload(
         name: draft.name.trim(),
         description: draft.description.trim() || undefined,
         source: draft.source,
-        durationWeeks: draft.blocks.reduce((sum, b) => sum + b.durationWeeks, 0),
+        durationWeeks: totalDurationWeeks,
         isPublic: false,
         createdBy: userId,
-        createdAt: now,
+        createdAt: draft.createdAt ?? now,
         updatedAt: now,
       },
-      blocks: blocksPayload as Array<{
-        block: Omit<Block, 'programId'>
-        weeks: Array<{
-          week: Omit<BlockWeek, 'blockId'>
-          sessions: Array<Omit<ScheduledSession, 'id' | 'blockWeekId'>>
-        }>
-      }>,
+      blocks: buildUpdateBlocksPayload(draft.blocks),
     }
   }
 
-  // Create mode
   return {
     mode: 'create' as const,
     program: {
@@ -379,22 +402,18 @@ export function buildSavePayload(
       name: draft.name.trim(),
       description: draft.description.trim() || undefined,
       source: draft.source,
-      durationWeeks: draft.blocks.reduce((sum, b) => sum + b.durationWeeks, 0),
+      durationWeeks: totalDurationWeeks,
       isPublic: false,
       createdBy: userId,
     },
-    blocks: blocksPayload as Array<{
-      block: Omit<Block, 'id' | 'programId'>
-      weeks: Array<{
-        week: Omit<BlockWeek, 'id' | 'blockId'>
-        sessions: Array<Omit<ScheduledSession, 'id' | 'blockWeekId'>>
-      }>
-    }>,
+    blocks: buildCreateBlocksPayload(draft.blocks),
   }
 }
 
 // ---------------------------------------------------------------------------
 // Hydrate draft from ProgramFull (edit mode)
+// Preserves original DB IDs as clientIds so buildSavePayload sends correct
+// IDs in update mode rather than fabricating new ones.
 // ---------------------------------------------------------------------------
 
 export function hydrateDraft(programFull: ProgramFull): ProgramDraft {
@@ -424,8 +443,8 @@ export function hydrateDraft(programFull: ProgramFull): ProgramDraft {
         .map((week) => {
           const sessions = (sessionsByWeek.get(week.id) ?? []).map(
             (session): SessionDraft => ({
-              clientId: crypto.randomUUID(),
-              dayOfWeek: session.dayOfWeek ?? null,
+              clientId: session.id,
+              dayOfWeek: (session.dayOfWeek as DayOfWeek) ?? null,
               dayLabel: session.dayLabel,
               sessionType: session.sessionType,
               sessionTemplateId: session.sessionTemplateId,
@@ -433,17 +452,16 @@ export function hydrateDraft(programFull: ProgramFull): ProgramDraft {
           )
 
           return {
-            clientId: crypto.randomUUID(),
+            clientId: week.id,
             weekNumber: week.weekNumber,
             sessions,
           } satisfies WeekDraft
         })
 
       return {
-        clientId: crypto.randomUUID(),
+        clientId: block.id,
         name: block.name,
         ordinal: block.ordinal,
-        durationWeeks: block.durationWeeks,
         blockType: block.blockType,
         weeks,
       } satisfies BlockDraft
@@ -454,6 +472,8 @@ export function hydrateDraft(programFull: ProgramFull): ProgramDraft {
     name: program.name,
     description: program.description ?? '',
     source: program.source,
+    createdAt: program.createdAt,
+    updatedAt: program.updatedAt,
     blocks: blockDrafts,
   }
 }

--- a/src/components/program-builder/constants.ts
+++ b/src/components/program-builder/constants.ts
@@ -1,0 +1,81 @@
+import type { BlockType } from '@/domain/types'
+
+// ---------------------------------------------------------------------------
+// DayOfWeek type alias (0=Sun, 1=Mon, ..., 6=Sat -- JS convention)
+// ---------------------------------------------------------------------------
+
+export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+// ---------------------------------------------------------------------------
+// Block types
+// ---------------------------------------------------------------------------
+
+export const BLOCK_TYPES: Array<{ value: BlockType; label: string }> = [
+  { value: 'ACCUMULATION', label: 'ACCUMULATION' },
+  { value: 'INTENSIFICATION', label: 'INTENSIFICATION' },
+  { value: 'REALIZATION', label: 'REALIZATION' },
+  { value: 'DELOAD', label: 'DELOAD' },
+  { value: 'TEST', label: 'TEST' },
+]
+
+// ---------------------------------------------------------------------------
+// Day column headers for 7-day grids (Mon through Sun)
+// ---------------------------------------------------------------------------
+
+export const DAY_COLUMNS: Array<{ dayOfWeek: DayOfWeek; label: string }> = [
+  { dayOfWeek: 1, label: 'M' },
+  { dayOfWeek: 2, label: 'T' },
+  { dayOfWeek: 3, label: 'W' },
+  { dayOfWeek: 4, label: 'T' },
+  { dayOfWeek: 5, label: 'F' },
+  { dayOfWeek: 6, label: 'S' },
+  { dayOfWeek: 0, label: 'S' },
+]
+
+// ---------------------------------------------------------------------------
+// Day labels -- full names, keyed 0-6
+// ---------------------------------------------------------------------------
+
+export const DAY_LABELS: Record<DayOfWeek, string> = {
+  0: 'Sunday',
+  1: 'Monday',
+  2: 'Tuesday',
+  3: 'Wednesday',
+  4: 'Thursday',
+  5: 'Friday',
+  6: 'Saturday',
+}
+
+// ---------------------------------------------------------------------------
+// Day abbreviations -- short names, keyed 0-6
+// ---------------------------------------------------------------------------
+
+export const DAY_ABBREVIATIONS: Record<DayOfWeek, string> = {
+  0: 'Sun',
+  1: 'Mon',
+  2: 'Tue',
+  3: 'Wed',
+  4: 'Thu',
+  5: 'Fri',
+  6: 'Sat',
+}
+
+// ---------------------------------------------------------------------------
+// Day order for iteration (Mon through Sun)
+// ---------------------------------------------------------------------------
+
+export const DAY_ORDER: DayOfWeek[] = [1, 2, 3, 4, 5, 6, 0]
+
+// ---------------------------------------------------------------------------
+// Source labels for program source badges
+// ---------------------------------------------------------------------------
+
+export const SOURCE_LABELS: Record<string, string> = {
+  CUSTOM: 'CUSTOM',
+  IMPORTED: 'IMPORTED',
+  SHARED: 'SHARED',
+  MARKETPLACE: 'MARKETPLACE',
+  AI_GENERATED: 'AI',
+  COACH_ASSIGNED: 'COACH',
+  TEMPLATE: 'TEMPLATE',
+}

--- a/src/components/program-builder/copy-week-dialog.tsx
+++ b/src/components/program-builder/copy-week-dialog.tsx
@@ -31,6 +31,11 @@ export function CopyWeekDialog({
   onCopy,
 }: CopyWeekDialogProps) {
   const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [prevSourceId, setPrevSourceId] = useState(sourceWeek.clientId)
+  if (prevSourceId !== sourceWeek.clientId) {
+    setPrevSourceId(sourceWeek.clientId)
+    setSelected(new Set())
+  }
 
   // Non-source weeks only
   const targetWeeks = allWeeks.filter((w) => w.clientId !== sourceWeek.clientId)
@@ -48,7 +53,7 @@ export function CopyWeekDialog({
   }, [])
 
   const handleSelectAllRemaining = useCallback(() => {
-    // Select all weeks after source week
+    // Select all weeks after the source week within this block
     const sourceIndex = allWeeks.findIndex((w) => w.clientId === sourceWeek.clientId)
     const remaining = allWeeks.slice(sourceIndex + 1).map((w) => w.clientId)
     setSelected(new Set(remaining))

--- a/src/components/program-builder/mobile-block-editor.tsx
+++ b/src/components/program-builder/mobile-block-editor.tsx
@@ -9,33 +9,10 @@ import {
   removeWeekFromBlock,
   removeSession,
 } from './builder-state'
-import type { ProgramDraft, BlockDraft } from './builder-state'
+import type { ProgramDraft, BlockDraft, SessionDraft } from './builder-state'
 import type { BlockType } from '@/domain/types'
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const BLOCK_TYPES: Array<{ value: BlockType; label: string }> = [
-  { value: 'ACCUMULATION', label: 'ACCUMULATION' },
-  { value: 'INTENSIFICATION', label: 'INTENSIFICATION' },
-  { value: 'REALIZATION', label: 'REALIZATION' },
-  { value: 'DELOAD', label: 'DELOAD' },
-  { value: 'TEST', label: 'TEST' },
-]
-
-const DAY_LABELS: Record<number, string> = {
-  0: 'Sun',
-  1: 'Mon',
-  2: 'Tue',
-  3: 'Wed',
-  4: 'Thu',
-  5: 'Fri',
-  6: 'Sat',
-}
-
-// Day order: Mon(1) through Sun(0)
-const DAY_ORDER = [1, 2, 3, 4, 5, 6, 0]
+import { BLOCK_TYPES, DAY_ABBREVIATIONS, DAY_ORDER } from './constants'
+import type { DayOfWeek } from './constants'
 
 // ---------------------------------------------------------------------------
 // MobileBlockEditor
@@ -44,7 +21,7 @@ const DAY_ORDER = [1, 2, 3, 4, 5, 6, 0]
 interface MobileBlockEditorProps {
   draft: ProgramDraft
   onUpdate: (draft: ProgramDraft) => void
-  onPickSession: (weekClientId: string, dayOfWeek: number) => void
+  onPickSession: (weekClientId: string, dayOfWeek: DayOfWeek) => void
   onCopyWeek: (sourceWeekClientId: string) => void
 }
 
@@ -89,6 +66,15 @@ export function MobileBlockEditor({
 // MobileBlockCard -- expandable accordion card for each block
 // ---------------------------------------------------------------------------
 
+interface MobileBlockCardProps {
+  block: BlockDraft
+  blockIndex: number
+  draft: ProgramDraft
+  onUpdate: (draft: ProgramDraft) => void
+  onPickSession: (weekClientId: string, dayOfWeek: DayOfWeek) => void
+  onCopyWeek: (sourceWeekClientId: string) => void
+}
+
 function MobileBlockCard({
   block,
   blockIndex,
@@ -96,14 +82,7 @@ function MobileBlockCard({
   onUpdate,
   onPickSession,
   onCopyWeek,
-}: {
-  block: BlockDraft
-  blockIndex: number
-  draft: ProgramDraft
-  onUpdate: (draft: ProgramDraft) => void
-  onPickSession: (weekClientId: string, dayOfWeek: number) => void
-  onCopyWeek: (sourceWeekClientId: string) => void
-}) {
+}: MobileBlockCardProps) {
   const [expanded, setExpanded] = useState(blockIndex === 0)
   const [isEditingName, setIsEditingName] = useState(false)
 
@@ -152,9 +131,7 @@ function MobileBlockCard({
 
   return (
     <div className="bg-surface-iron">
-      {/* Card header */}
       <div className="flex min-h-12 items-center gap-2 px-3 py-2">
-        {/* Block name */}
         {isEditingName ? (
           <input
             type="text"
@@ -178,17 +155,14 @@ function MobileBlockCard({
           </button>
         )}
 
-        {/* Block type badge */}
         <span className="bg-surface-steel px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-bone-white">
           {block.blockType}
         </span>
 
-        {/* Duration label */}
         <span className="text-[10px] font-medium uppercase tracking-wider text-warm-ash/60">
-          {block.durationWeeks} {block.durationWeeks === 1 ? 'WK' : 'WKS'}
+          {block.weeks.length} {block.weeks.length === 1 ? 'WK' : 'WKS'}
         </span>
 
-        {/* Move up */}
         <button
           type="button"
           onClick={handleMoveUp}
@@ -199,7 +173,6 @@ function MobileBlockCard({
           <Icon name="arrow_upward" size={18} />
         </button>
 
-        {/* Move down */}
         <button
           type="button"
           onClick={handleMoveDown}
@@ -210,7 +183,6 @@ function MobileBlockCard({
           <Icon name="arrow_downward" size={18} />
         </button>
 
-        {/* Delete */}
         <button
           type="button"
           onClick={handleDelete}
@@ -220,7 +192,6 @@ function MobileBlockCard({
           <Icon name="delete" size={18} />
         </button>
 
-        {/* Expand/collapse */}
         <button
           type="button"
           onClick={() => setExpanded((prev) => !prev)}
@@ -234,7 +205,6 @@ function MobileBlockCard({
       {/* Expanded content */}
       {expanded && (
         <div className="flex flex-col gap-4 px-3 pb-4">
-          {/* Block type selector */}
           <div className="flex flex-wrap gap-1">
             {BLOCK_TYPES.map((bt) => (
               <button
@@ -252,7 +222,6 @@ function MobileBlockCard({
             ))}
           </div>
 
-          {/* Weeks */}
           {block.weeks.map((week, weekIndex) => (
             <MobileWeekSection
               key={week.clientId}
@@ -267,7 +236,6 @@ function MobileBlockCard({
             />
           ))}
 
-          {/* Add week button */}
           <Button
             type="button"
             variant="secondary"
@@ -287,6 +255,17 @@ function MobileBlockCard({
 // MobileWeekSection -- vertical list of day slots for a week
 // ---------------------------------------------------------------------------
 
+interface MobileWeekSectionProps {
+  weekIndex: number
+  weekClientId: string
+  sessions: SessionDraft[]
+  draft: ProgramDraft
+  blockClientId: string
+  onUpdate: (draft: ProgramDraft) => void
+  onPickSession: (weekClientId: string, dayOfWeek: DayOfWeek) => void
+  onCopyWeek: (sourceWeekClientId: string) => void
+}
+
 function MobileWeekSection({
   weekIndex,
   weekClientId,
@@ -296,16 +275,7 @@ function MobileWeekSection({
   onUpdate,
   onPickSession,
   onCopyWeek,
-}: {
-  weekIndex: number
-  weekClientId: string
-  sessions: ProgramDraft['blocks'][0]['weeks'][0]['sessions']
-  draft: ProgramDraft
-  blockClientId: string
-  onUpdate: (draft: ProgramDraft) => void
-  onPickSession: (weekClientId: string, dayOfWeek: number) => void
-  onCopyWeek: (sourceWeekClientId: string) => void
-}) {
+}: MobileWeekSectionProps) {
   // Build session lookup by dayOfWeek
   const sessionsByDay = new Map(
     sessions.filter((s) => s.dayOfWeek !== null).map((s) => [s.dayOfWeek!, s]),
@@ -321,7 +291,6 @@ function MobileWeekSection({
 
   return (
     <div className="flex flex-col gap-1">
-      {/* Week header */}
       <div className="flex items-center gap-2">
         <span className="text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
           WEEK {weekIndex + 1}
@@ -344,7 +313,6 @@ function MobileWeekSection({
         </button>
       </div>
 
-      {/* Day rows -- vertical list */}
       <div className="flex flex-col gap-1">
         {DAY_ORDER.map((dayOfWeek) => {
           const session = sessionsByDay.get(dayOfWeek)
@@ -370,6 +338,15 @@ function MobileWeekSection({
 // MobileDayRow -- single day slot as a tappable row
 // ---------------------------------------------------------------------------
 
+interface MobileDayRowProps {
+  dayOfWeek: DayOfWeek
+  session: SessionDraft | undefined
+  weekClientId: string
+  draft: ProgramDraft
+  onUpdate: (draft: ProgramDraft) => void
+  onPickSession: (weekClientId: string, dayOfWeek: DayOfWeek) => void
+}
+
 function MobileDayRow({
   dayOfWeek,
   session,
@@ -377,14 +354,7 @@ function MobileDayRow({
   draft,
   onUpdate,
   onPickSession,
-}: {
-  dayOfWeek: number
-  session: ProgramDraft['blocks'][0]['weeks'][0]['sessions'][0] | undefined
-  weekClientId: string
-  draft: ProgramDraft
-  onUpdate: (draft: ProgramDraft) => void
-  onPickSession: (weekClientId: string, dayOfWeek: number) => void
-}) {
+}: MobileDayRowProps) {
   const handleTap = useCallback(() => {
     onPickSession(weekClientId, dayOfWeek)
   }, [weekClientId, dayOfWeek, onPickSession])
@@ -405,10 +375,10 @@ function MobileDayRow({
         type="button"
         onClick={handleTap}
         className="flex min-h-12 items-center gap-3 bg-surface-charcoal px-3 py-2 text-left transition-colors hover:bg-surface-steel"
-        aria-label={`Assign session to ${DAY_LABELS[dayOfWeek]}`}
+        aria-label={`Assign session to ${DAY_ABBREVIATIONS[dayOfWeek]}`}
       >
         <span className="w-8 text-[10px] font-medium uppercase tracking-wider text-warm-ash/60">
-          {DAY_LABELS[dayOfWeek]}
+          {DAY_ABBREVIATIONS[dayOfWeek]}
         </span>
         <span className="flex-1 text-xs text-warm-ash/40">TAP TO ASSIGN</span>
         <Icon name="add" size={16} className="text-warm-ash/30" />
@@ -421,10 +391,10 @@ function MobileDayRow({
       type="button"
       onClick={handleTap}
       className="flex min-h-12 items-center gap-3 bg-surface-charcoal px-3 py-2 text-left transition-colors hover:bg-surface-steel"
-      aria-label={`Session: ${session.templateName ?? 'Unnamed'} on ${DAY_LABELS[dayOfWeek]}`}
+      aria-label={`Session: ${session.templateName ?? 'Unnamed'} on ${DAY_ABBREVIATIONS[dayOfWeek]}`}
     >
       <span className="w-8 text-[10px] font-medium uppercase tracking-wider text-warm-ash/60">
-        {DAY_LABELS[dayOfWeek]}
+        {DAY_ABBREVIATIONS[dayOfWeek]}
       </span>
       <span className="min-w-0 flex-1 truncate text-xs text-bone-white">
         {session.templateName ?? 'Unnamed'}

--- a/src/components/program-builder/program-form.tsx
+++ b/src/components/program-builder/program-form.tsx
@@ -21,13 +21,12 @@ const PROGRAM_SOURCES: Array<{ value: ProgramSource; label: string }> = [
 
 interface ProgramFormProps {
   draft: ProgramDraft
-  onChange: (updates: Partial<ProgramDraft>) => void
+  onChange: (updates: Partial<Pick<ProgramDraft, 'name' | 'description' | 'source'>>) => void
 }
 
 export function ProgramForm({ draft, onChange }: ProgramFormProps) {
   return (
     <div className="flex flex-col gap-6">
-      {/* Program name */}
       <div>
         <span className="mb-1 block text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
           PROGRAM NAME
@@ -42,7 +41,6 @@ export function ProgramForm({ draft, onChange }: ProgramFormProps) {
         />
       </div>
 
-      {/* Description */}
       <div>
         <span className="mb-1 block text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
           DESCRIPTION (OPTIONAL)
@@ -57,7 +55,6 @@ export function ProgramForm({ draft, onChange }: ProgramFormProps) {
         />
       </div>
 
-      {/* Source selector */}
       <div>
         <span className="mb-2 block text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
           SOURCE

--- a/src/components/program-builder/program-preview.tsx
+++ b/src/components/program-builder/program-preview.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { useQueries } from '@tanstack/react-query'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Icon } from '@/components/icon'
 import { useAuth } from '@/lib/auth'
@@ -9,30 +10,7 @@ import { getAdapter } from '@/lib/adapter'
 import type { ProgramDraft } from './builder-state'
 import type { SessionTemplateFull } from '@/lib/data-adapter'
 import type { SetScheme } from '@/domain/types'
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const DAY_COLUMNS = [
-  { dayOfWeek: 1, label: 'M' },
-  { dayOfWeek: 2, label: 'T' },
-  { dayOfWeek: 3, label: 'W' },
-  { dayOfWeek: 4, label: 'T' },
-  { dayOfWeek: 5, label: 'F' },
-  { dayOfWeek: 6, label: 'S' },
-  { dayOfWeek: 0, label: 'S' },
-]
-
-const SOURCE_LABELS: Record<string, string> = {
-  CUSTOM: 'CUSTOM',
-  IMPORTED: 'IMPORTED',
-  SHARED: 'SHARED',
-  MARKETPLACE: 'MARKETPLACE',
-  AI_GENERATED: 'AI',
-  COACH_ASSIGNED: 'COACH',
-  TEMPLATE: 'TEMPLATE',
-}
+import { DAY_COLUMNS, SOURCE_LABELS } from './constants'
 
 // ---------------------------------------------------------------------------
 // Set scheme summary helpers
@@ -197,10 +175,11 @@ function useSessionTemplatesFull(draft: ProgramDraft) {
 
 interface ProgramPreviewProps {
   draft: ProgramDraft
+  open: boolean
   onClose: () => void
 }
 
-export function ProgramPreview({ draft, onClose }: ProgramPreviewProps) {
+export function ProgramPreview({ draft, open, onClose }: ProgramPreviewProps) {
   const { user } = useAuth()
   const userId = user?.id ?? ''
   const { data: profile } = useUserProfile(userId)
@@ -215,175 +194,174 @@ export function ProgramPreview({ draft, onClose }: ProgramPreviewProps) {
   const exerciseMaxes = profile?.exerciseMaxes ?? {}
 
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto bg-surface-anvil">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 pt-6 pb-4">
-        <div className="flex-1">
-          <h1 className="font-display text-2xl font-medium uppercase tracking-wider text-bone-white">
-            {draft.name || 'UNTITLED PROGRAM'}
-          </h1>
-          <div className="mt-1 flex items-center gap-2">
-            <span className="bg-surface-steel px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-bone-white">
-              {SOURCE_LABELS[draft.source] ?? draft.source}
-            </span>
-          </div>
-        </div>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={onClose}
-          className="min-h-10 text-xs uppercase tracking-wider text-warm-ash hover:text-bone-white"
-        >
-          CLOSE PREVIEW
-          <Icon name="close" size={16} />
-        </Button>
-      </div>
-
-      {/* Description */}
-      {draft.description && (
-        <div className="px-4 pb-4">
-          <p className="text-sm text-warm-ash">{draft.description}</p>
-        </div>
-      )}
-
-      {/* Blocks */}
-      <div className="flex flex-col gap-6 px-4 pb-8">
-        {draft.blocks.map((block) => (
-          <div key={block.clientId} className="bg-surface-iron">
-            {/* Block header */}
-            <div className="flex items-center gap-3 px-3 py-3">
-              <span className="font-display text-sm font-medium uppercase tracking-wider text-bone-white">
-                {block.name || 'UNTITLED BLOCK'}
-              </span>
-              <span className="bg-surface-steel px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-bone-white">
-                {block.blockType}
-              </span>
-              <span className="text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
-                {block.durationWeeks} {block.durationWeeks === 1 ? 'WEEK' : 'WEEKS'}
-              </span>
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent
+        className="max-w-none h-screen w-screen p-0 border-0 rounded-none bg-surface-anvil"
+        showCloseButton={false}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <div className="h-full overflow-y-auto">
+          <div className="flex items-center justify-between px-4 pt-6 pb-4">
+            <div className="flex-1">
+              <h1 className="font-display text-2xl font-medium uppercase tracking-wider text-bone-white">
+                {draft.name || 'UNTITLED PROGRAM'}
+              </h1>
+              <div className="mt-1 flex items-center gap-2">
+                <span className="bg-surface-steel px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-bone-white">
+                  {SOURCE_LABELS[draft.source] ?? draft.source}
+                </span>
+              </div>
             </div>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              className="min-h-10 text-xs uppercase tracking-wider text-warm-ash hover:text-bone-white"
+            >
+              CLOSE PREVIEW
+              <Icon name="close" size={16} />
+            </Button>
+          </div>
 
-            {/* Weeks */}
-            <div className="flex flex-col gap-4 px-3 pb-4">
-              {block.weeks.map((week, weekIdx) => {
-                const sessionsByDay = new Map(
-                  week.sessions.filter((s) => s.dayOfWeek !== null).map((s) => [s.dayOfWeek!, s]),
-                )
+          {draft.description && (
+            <div className="px-4 pb-4">
+              <p className="text-sm text-warm-ash">{draft.description}</p>
+            </div>
+          )}
 
-                return (
-                  <div key={week.clientId} className="flex flex-col gap-2">
-                    {/* Week header */}
-                    <span className="text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
-                      WEEK {weekIdx + 1}
-                    </span>
+          <div className="flex flex-col gap-6 px-4 pb-8">
+            {draft.blocks.map((block) => (
+              <div key={block.clientId} className="bg-surface-iron">
+                <div className="flex items-center gap-3 px-3 py-3">
+                  <span className="font-display text-sm font-medium uppercase tracking-wider text-bone-white">
+                    {block.name || 'UNTITLED BLOCK'}
+                  </span>
+                  <span className="bg-surface-steel px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-bone-white">
+                    {block.blockType}
+                  </span>
+                  <span className="text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
+                    {block.weeks.length} {block.weeks.length === 1 ? 'WEEK' : 'WEEKS'}
+                  </span>
+                </div>
 
-                    {/* 7-column day grid */}
-                    <div className="grid grid-cols-7 gap-1">
-                      {/* Day headers */}
-                      {DAY_COLUMNS.map((col) => (
-                        <div
-                          key={`hdr-${col.dayOfWeek}`}
-                          className="text-center text-[10px] font-medium uppercase tracking-widest text-warm-ash/60"
-                        >
-                          {col.label}
-                        </div>
-                      ))}
+                <div className="flex flex-col gap-4 px-3 pb-4">
+                  {block.weeks.map((week, weekIdx) => {
+                    const sessionsByDay = new Map(
+                      week.sessions
+                        .filter((s) => s.dayOfWeek !== null)
+                        .map((s) => [s.dayOfWeek!, s]),
+                    )
 
-                      {/* Day cells */}
-                      {DAY_COLUMNS.map((col) => {
-                        const session = sessionsByDay.get(col.dayOfWeek)
+                    return (
+                      <div key={week.clientId} className="flex flex-col gap-2">
+                        <span className="text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
+                          WEEK {weekIdx + 1}
+                        </span>
 
-                        if (!session) {
-                          return (
+                        {/* 7-column day grid */}
+                        <div className="grid grid-cols-7 gap-1">
+                          {DAY_COLUMNS.map((col) => (
                             <div
-                              key={`cell-${col.dayOfWeek}`}
-                              className="min-h-[60px] bg-surface-charcoal"
-                            />
-                          )
-                        }
-
-                        return (
-                          <div
-                            key={`cell-${col.dayOfWeek}`}
-                            className="flex min-h-[60px] flex-col bg-surface-charcoal p-1"
-                          >
-                            <span className="line-clamp-2 text-[9px] font-medium text-bone-white">
-                              {session.templateName ?? 'UNNAMED'}
-                            </span>
-                            <span className="mt-0.5 inline-block self-start bg-surface-steel px-1 py-0.5 text-[8px] font-medium uppercase tracking-wider text-warm-ash">
-                              {session.sessionType}
-                            </span>
-                          </div>
-                        )
-                      })}
-                    </div>
-
-                    {/* Session detail tables */}
-                    {week.sessions
-                      .filter((s) => s.dayOfWeek !== null)
-                      .map((session) => {
-                        const templateFull = sessionTemplates.get(session.sessionTemplateId)
-                        if (!templateFull) return null
-
-                        const groupedActivities = buildGroupedActivities(templateFull)
-                        if (groupedActivities.length === 0) return null
-
-                        return (
-                          <div key={session.clientId} className="flex flex-col gap-0">
-                            {/* Session name header */}
-                            <div className="bg-surface-steel px-2 py-1.5">
-                              <span className="text-[10px] font-medium uppercase tracking-wider text-bone-white">
-                                {session.templateName ?? 'UNNAMED'}
-                              </span>
+                              key={`hdr-${col.dayOfWeek}`}
+                              className="text-center text-[10px] font-medium uppercase tracking-widest text-warm-ash/60"
+                            >
+                              {col.label}
                             </div>
+                          ))}
 
-                            {/* Table header */}
-                            <div className="grid grid-cols-[1fr_auto_auto] gap-2 bg-surface-gunmetal px-2 py-1">
-                              <span className="text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
-                                EXERCISE
-                              </span>
-                              <span className="text-right text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
-                                SETS x REPS
-                              </span>
-                              <span className="w-20 text-right text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
-                                LOAD
-                              </span>
-                            </div>
+                          {DAY_COLUMNS.map((col) => {
+                            const session = sessionsByDay.get(col.dayOfWeek)
 
-                            {/* Activity rows */}
-                            {groupedActivities.map((activity, actIdx) => (
+                            if (!session) {
+                              return (
+                                <div
+                                  key={`cell-${col.dayOfWeek}`}
+                                  className="min-h-[60px] bg-surface-charcoal"
+                                />
+                              )
+                            }
+
+                            return (
                               <div
-                                key={`${session.clientId}-${actIdx}`}
-                                className={`grid grid-cols-[1fr_auto_auto] gap-2 px-2 py-1.5 ${
-                                  actIdx % 2 === 0 ? 'bg-surface-steel' : 'bg-surface-charcoal'
-                                }`}
+                                key={`cell-${col.dayOfWeek}`}
+                                className="flex min-h-[60px] flex-col bg-surface-charcoal p-1"
                               >
-                                <span className="text-xs text-bone-white">
-                                  {exerciseMap.get(activity.exerciseId) ?? 'Unknown Exercise'}
+                                <span className="line-clamp-2 text-[9px] font-medium text-bone-white">
+                                  {session.templateName ?? 'UNNAMED'}
                                 </span>
-                                <span className="text-right font-display text-xs text-bone-white">
-                                  {formatSetsReps(activity.setScheme)}
-                                </span>
-                                <span className="w-20 text-right font-display text-xs text-bone-white">
-                                  {formatLoad(
-                                    activity.setScheme,
-                                    exerciseMaxes,
-                                    activity.exerciseId,
-                                  )}
+                                <span className="mt-0.5 inline-block self-start bg-surface-steel px-1 py-0.5 text-[8px] font-medium uppercase tracking-wider text-warm-ash">
+                                  {session.sessionType}
                                 </span>
                               </div>
-                            ))}
-                          </div>
-                        )
-                      })}
-                  </div>
-                )
-              })}
-            </div>
+                            )
+                          })}
+                        </div>
+
+                        {/* Session detail tables */}
+                        {week.sessions
+                          .filter((s) => s.dayOfWeek !== null)
+                          .map((session) => {
+                            const templateFull = sessionTemplates.get(session.sessionTemplateId)
+                            if (!templateFull) return null
+
+                            const groupedActivities = buildGroupedActivities(templateFull)
+                            if (groupedActivities.length === 0) return null
+
+                            return (
+                              <div key={session.clientId} className="flex flex-col gap-0">
+                                <div className="bg-surface-steel px-2 py-1.5">
+                                  <span className="text-[10px] font-medium uppercase tracking-wider text-bone-white">
+                                    {session.templateName ?? 'UNNAMED'}
+                                  </span>
+                                </div>
+
+                                <div className="grid grid-cols-[1fr_auto_auto] gap-2 bg-surface-gunmetal px-2 py-1">
+                                  <span className="text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
+                                    EXERCISE
+                                  </span>
+                                  <span className="text-right text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
+                                    SETS x REPS
+                                  </span>
+                                  <span className="w-20 text-right text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
+                                    LOAD
+                                  </span>
+                                </div>
+
+                                {groupedActivities.map((activity, actIdx) => (
+                                  <div
+                                    key={`${session.clientId}-${actIdx}`}
+                                    className={`grid grid-cols-[1fr_auto_auto] gap-2 px-2 py-1.5 ${
+                                      actIdx % 2 === 0 ? 'bg-surface-steel' : 'bg-surface-charcoal'
+                                    }`}
+                                  >
+                                    <span className="text-xs text-bone-white">
+                                      {exerciseMap.get(activity.exerciseId) ?? 'Unknown Exercise'}
+                                    </span>
+                                    <span className="text-right font-display text-xs text-bone-white">
+                                      {formatSetsReps(activity.setScheme)}
+                                    </span>
+                                    <span className="w-20 text-right font-display text-xs text-bone-white">
+                                      {formatLoad(
+                                        activity.setScheme,
+                                        exerciseMaxes,
+                                        activity.exerciseId,
+                                      )}
+                                    </span>
+                                  </div>
+                                ))}
+                              </div>
+                            )
+                          })}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
-    </div>
+        </div>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/src/components/program-builder/session-picker-sheet.tsx
+++ b/src/components/program-builder/session-picker-sheet.tsx
@@ -47,7 +47,7 @@ export function SessionPickerSheet({
   const [filter, setFilter] = useState<SessionType | 'ALL'>('ALL')
   const [showCreate, setShowCreate] = useState(false)
 
-  // Debounced search -- simple approach using the raw value (300ms is handled via useMemo filtering)
+  // Filter templates by type and search query
   const filtered = useMemo(() => {
     let result = templates
 
@@ -115,7 +115,6 @@ export function SessionPickerSheet({
           </div>
         ) : (
           <>
-            {/* Search */}
             <div className="px-4 pt-3">
               <input
                 type="text"
@@ -127,7 +126,6 @@ export function SessionPickerSheet({
               />
             </div>
 
-            {/* Filter badges */}
             <div className="flex flex-wrap gap-1 px-4 pt-3">
               {SESSION_FILTERS.map((f) => (
                 <button
@@ -145,7 +143,6 @@ export function SessionPickerSheet({
               ))}
             </div>
 
-            {/* Template list */}
             <div className="flex-1 overflow-y-auto px-4 pt-3 pb-4">
               {isLoading ? (
                 <div className="flex flex-col gap-2">

--- a/src/components/program-builder/session-slot.tsx
+++ b/src/components/program-builder/session-slot.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { Icon } from '@/components/icon'
 import { removeSession } from './builder-state'
 import type { SessionDraft, ProgramDraft } from './builder-state'
+import type { DayOfWeek } from './constants'
 
 // ---------------------------------------------------------------------------
 // SessionSlot
@@ -9,11 +10,11 @@ import type { SessionDraft, ProgramDraft } from './builder-state'
 
 interface SessionSlotProps {
   session: SessionDraft | undefined
-  dayOfWeek: number
+  dayOfWeek: DayOfWeek
   weekClientId: string
   draft: ProgramDraft
   onUpdate: (draft: ProgramDraft) => void
-  onPickSession: (weekClientId: string, dayOfWeek: number) => void
+  onPickSession: (weekClientId: string, dayOfWeek: DayOfWeek) => void
 }
 
 export function SessionSlot({
@@ -39,7 +40,6 @@ export function SessionSlot({
   }, [weekClientId, dayOfWeek, onPickSession])
 
   if (!session) {
-    // Empty state
     return (
       <button
         type="button"
@@ -52,7 +52,6 @@ export function SessionSlot({
     )
   }
 
-  // Filled state
   return (
     <div
       className="relative flex min-h-[80px] cursor-pointer flex-col justify-center bg-surface-charcoal p-2 transition-colors hover:bg-surface-iron"
@@ -64,7 +63,6 @@ export function SessionSlot({
       }}
       aria-label={`Session: ${session.templateName ?? 'Unnamed'}`}
     >
-      {/* Remove button */}
       <button
         type="button"
         onClick={handleRemove}
@@ -74,12 +72,10 @@ export function SessionSlot({
         <Icon name="close" size={14} />
       </button>
 
-      {/* Template name */}
       <span className="line-clamp-2 pr-4 font-body text-xs text-bone-white">
         {session.templateName ?? 'Unnamed'}
       </span>
 
-      {/* Session type badge */}
       <span className="mt-1 inline-block self-start bg-surface-steel px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-warm-ash">
         {session.sessionType}
       </span>

--- a/src/components/program-builder/week-grid.tsx
+++ b/src/components/program-builder/week-grid.tsx
@@ -3,21 +3,8 @@ import { Icon } from '@/components/icon'
 import { SessionSlot } from './session-slot'
 import { removeWeekFromBlock } from './builder-state'
 import type { WeekDraft, ProgramDraft } from './builder-state'
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-// Day columns: Mon(1) through Sun(0)
-const DAY_COLUMNS = [
-  { dayOfWeek: 1, label: 'M' },
-  { dayOfWeek: 2, label: 'T' },
-  { dayOfWeek: 3, label: 'W' },
-  { dayOfWeek: 4, label: 'T' },
-  { dayOfWeek: 5, label: 'F' },
-  { dayOfWeek: 6, label: 'S' },
-  { dayOfWeek: 0, label: 'S' },
-]
+import { DAY_COLUMNS } from './constants'
+import type { DayOfWeek } from './constants'
 
 // ---------------------------------------------------------------------------
 // WeekGrid
@@ -29,7 +16,7 @@ interface WeekGridProps {
   draft: ProgramDraft
   blockClientId: string
   onUpdate: (draft: ProgramDraft) => void
-  onPickSession: (weekClientId: string, dayOfWeek: number) => void
+  onPickSession: (weekClientId: string, dayOfWeek: DayOfWeek) => void
   onCopyWeek: (sourceWeekClientId: string) => void
 }
 
@@ -57,7 +44,6 @@ export function WeekGrid({
 
   return (
     <div className="flex flex-col gap-1">
-      {/* Week header */}
       <div className="flex items-center gap-2">
         <span className="text-[10px] font-medium uppercase tracking-widest text-warm-ash/60">
           WEEK {weekIndex + 1}
@@ -80,7 +66,6 @@ export function WeekGrid({
         </button>
       </div>
 
-      {/* Day column headers */}
       <div className="grid grid-cols-7 gap-1 overflow-x-auto">
         {DAY_COLUMNS.map((col) => (
           <div
@@ -92,7 +77,6 @@ export function WeekGrid({
         ))}
       </div>
 
-      {/* Session slots */}
       <div className="grid grid-cols-7 gap-1 overflow-x-auto">
         {DAY_COLUMNS.map((col) => (
           <SessionSlot

--- a/src/routes/builder.tsx
+++ b/src/routes/builder.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useAuth } from '@/lib/auth'
 import { useProgramFull, useCreateProgram, useUpdateProgram } from '@/hooks/use-programs'
@@ -20,6 +20,7 @@ import {
   buildSavePayload,
 } from '@/components/program-builder/builder-state'
 import type { ProgramDraft, WeekDraft } from '@/components/program-builder/builder-state'
+import type { DayOfWeek } from '@/components/program-builder/constants'
 import type { SessionType } from '@/domain/types'
 
 // ---------------------------------------------------------------------------
@@ -48,7 +49,7 @@ function BuilderPage() {
   // Session picker state
   const [pickerState, setPickerState] = useState<{
     weekClientId: string
-    dayOfWeek: number
+    dayOfWeek: DayOfWeek
   } | null>(null)
 
   // Copy week dialog state
@@ -69,9 +70,8 @@ function BuilderPage() {
   // Edit mode: fetch existing program
   const { data: programFull, isLoading: isLoadingProgram } = useProgramFull(programId)
 
-  // Hydrate draft when program data loads.
-  // Track the last-hydrated program ID as state to avoid calling setState in an effect.
-  // React allows conditional setState during render for "adjusting state based on props".
+  // Track last-hydrated ID to ensure we hydrate only once per program. Uses React's
+  // "adjusting state during render" pattern instead of useEffect to avoid an extra render cycle.
   const [hydratedProgramId, setHydratedProgramId] = useState<string | null>(null)
   if (programFull && hydratedProgramId !== programFull.program.id) {
     setHydratedProgramId(programFull.program.id)
@@ -96,23 +96,32 @@ function BuilderPage() {
     setError(null)
   }, [])
 
-  const handleDraftChange = useCallback((updates: Partial<ProgramDraft>) => {
-    setDraft((prev) => ({ ...prev, ...updates }))
-    setError(null)
-  }, [])
+  const handleDraftChange = useCallback(
+    (updates: Partial<Pick<ProgramDraft, 'name' | 'description' | 'source'>>) => {
+      setDraft((prev) => ({ ...prev, ...updates }))
+      setError(null)
+    },
+    [],
+  )
 
-  const handlePickSession = useCallback((weekClientId: string, dayOfWeek: number) => {
+  const handlePickSession = useCallback((weekClientId: string, dayOfWeek: DayOfWeek) => {
     setPickerState({ weekClientId, dayOfWeek })
   }, [])
 
+  const pickerStateRef = useRef(pickerState)
+  useEffect(() => {
+    pickerStateRef.current = pickerState
+  })
+
   const handleSessionSelected = useCallback(
     (templateId: string, templateName: string, sessionType: SessionType) => {
-      if (!pickerState) return
+      const state = pickerStateRef.current
+      if (!state) return
       setDraft((prev) =>
         assignSession(
           prev,
-          pickerState.weekClientId,
-          pickerState.dayOfWeek,
+          state.weekClientId,
+          state.dayOfWeek,
           templateId,
           templateName,
           sessionType,
@@ -120,7 +129,7 @@ function BuilderPage() {
       )
       setPickerState(null)
     },
-    [pickerState],
+    [],
   )
 
   const handleCopyWeek = useCallback(
@@ -318,7 +327,7 @@ function BuilderPage() {
       )}
 
       {/* Program preview overlay */}
-      {previewMode && <ProgramPreview draft={draft} onClose={() => setPreviewMode(false)} />}
+      <ProgramPreview draft={draft} open={previewMode} onClose={() => setPreviewMode(false)} />
     </div>
   )
 }

--- a/src/routes/library.tsx
+++ b/src/routes/library.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/sheet'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Icon } from '@/components/icon'
+import { SOURCE_LABELS } from '@/components/program-builder/constants'
 import { SessionTemplateCard } from '@/components/session-builder/session-template-card'
 import {
   SessionTemplateForm,
@@ -234,16 +235,6 @@ function LibraryPage() {
 // ---------------------------------------------------------------------------
 // Program list panel
 // ---------------------------------------------------------------------------
-
-const SOURCE_LABELS: Record<string, string> = {
-  CUSTOM: 'CUSTOM',
-  IMPORTED: 'IMPORTED',
-  SHARED: 'SHARED',
-  MARKETPLACE: 'MARKETPLACE',
-  AI_GENERATED: 'AI',
-  COACH_ASSIGNED: 'COACH',
-  TEMPLATE: 'TEMPLATE',
-}
 
 function ProgramList({ userId }: { userId: string | undefined }) {
   const navigate = useNavigate()


### PR DESCRIPTION
## Summary

- **Builder state layer** (`builder-state.ts`): immutable `ProgramDraft` state with full helper set (`addBlock`, `removeBlock`, `reorderBlocks`, `addWeekToBlock`, `removeWeekFromBlock`, `assignSession`, `removeSession`, `copyWeek`, `buildSavePayload`, `hydrateDraft`, `validateDraft`)
- **Desktop DnD editor**: `BlockList` + `BlockEditor` using `@dnd-kit/sortable` with vertical-axis restriction, drag handles, inline block name editing, and block type badge selector
- **Week + session layer**: `WeekGrid` (7-column CSS grid) + `SessionSlot` (empty/filled states with tap-to-assign)
- **Session picker**: `SessionPickerSheet` with debounced search, session type filter, template list, and inline `SessionTemplateForm` creation
- **Copy week**: `CopyWeekDialog` with checkbox target selection and SELECT ALL REMAINING shortcut
- **Program preview**: `ProgramPreview` read-only overlay with calculated weights for `PercentageSets` schemes using user 1RMs
- **Mobile editor**: `MobileBlockEditor` accordion list with up/down reorder buttons (no DnD), vertical day-slot list
- **Builder page** (`builder.tsx`): auth redirect, `programId` search param for edit mode, draft hydration from `useProgramFull`, desktop sidebar layout, responsive mobile/desktop split, PREVIEW overlay, SAVE PROGRAM CTA wired to `useCreateProgram` / `useUpdateProgram`
- **Library integration** (`library.tsx`): CREATE PROGRAM forge CTA + edit button navigates to `/builder?programId={id}`

## Test plan

- [ ] Navigate to `/library` -> Programs tab -> click CREATE PROGRAM -> lands on builder with empty draft
- [ ] Fill in program name, pick source badge, add a block, add a week, assign session templates to days
- [ ] Drag blocks to reorder (desktop)
- [ ] Copy a week via the copy icon
- [ ] Save program -> appears in library programs list
- [ ] Edit an existing program -> builder loads with existing data
- [ ] BACK TO LIBRARY button returns to library
- [ ] PREVIEW button opens read-only overlay; CLOSE PREVIEW returns to editor
- [ ] On mobile viewport (<768px): DnD editor hidden, mobile accordion visible; up/down buttons reorder blocks
- [ ] `bun run build` -- zero TypeScript errors
- [ ] `bun run lint` -- zero errors