### PR TITLE
feat: VAULT analytics screen, PR detection, and exercise records (Step 14)

### DIFF
--- a/src/components/vault/vault-metric-card.tsx
+++ b/src/components/vault/vault-metric-card.tsx
@@ -1,0 +1,17 @@
+interface VaultMetricCardProps {
+  label: string
+  value: string | number
+  subValue?: string
+}
+
+export function VaultMetricCard({ label, value, subValue }: VaultMetricCardProps) {
+  return (
+    <div className="bg-surface-iron p-4">
+      <span className="font-body text-xs font-medium uppercase tracking-widest text-warm-ash">
+        {label}
+      </span>
+      <p className="mt-1 font-display text-readout text-bone-white">{value}</p>
+      {subValue && <span className="font-body text-xs text-warm-ash/60">{subValue}</span>}
+    </div>
+  )
+}

--- a/src/components/vault/vault-one-rm-tab.tsx
+++ b/src/components/vault/vault-one-rm-tab.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { useAuth } from '@/lib/auth'
+import { useExercises } from '@/hooks/use-exercises'
+import { useOneRepMaxHistory } from '@/hooks/use-user-profile'
+import { OneRmChart } from '@/components/exercises/one-rm-chart'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function VaultOneRmTab() {
+  const { user } = useAuth()
+  const userId = user?.id
+  const { data: exercises, isLoading: isLoadingExercises } = useExercises()
+  const [selectedExerciseId, setSelectedExerciseId] = useState<string | undefined>(undefined)
+
+  const { data: oneRmHistory, isLoading: isLoadingHistory } = useOneRepMaxHistory(
+    userId,
+    selectedExerciseId,
+  )
+
+  const oneRmExercises = exercises?.filter((e) => e.supports1RM) ?? []
+
+  if (isLoadingExercises) {
+    return (
+      <div className="space-y-4 pt-4">
+        <Skeleton className="h-10 w-full rounded-none bg-surface-steel" />
+        <Skeleton className="h-52 w-full rounded-none bg-surface-steel" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 pt-4">
+      <Select
+        value={selectedExerciseId ?? ''}
+        onValueChange={(val) => setSelectedExerciseId(val || undefined)}
+      >
+        <SelectTrigger className="min-h-12 w-full border-surface-steel bg-surface-iron font-body text-sm text-bone-white">
+          <SelectValue placeholder="Select an exercise" />
+        </SelectTrigger>
+        <SelectContent className="bg-surface-iron">
+          {oneRmExercises.map((exercise) => (
+            <SelectItem key={exercise.id} value={exercise.id}>
+              {exercise.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {!selectedExerciseId && (
+        <div className="flex items-center justify-center bg-surface-iron p-8">
+          <p className="font-display text-sm text-warm-ash">
+            Select an exercise to view 1RM trends
+          </p>
+        </div>
+      )}
+
+      {selectedExerciseId && isLoadingHistory && (
+        <Skeleton className="h-52 w-full rounded-none bg-surface-steel" />
+      )}
+
+      {selectedExerciseId && !isLoadingHistory && <OneRmChart data={oneRmHistory ?? []} />}
+    </div>
+  )
+}

--- a/src/components/vault/vault-overview.tsx
+++ b/src/components/vault/vault-overview.tsx
@@ -1,0 +1,56 @@
+import { useAuth } from '@/lib/auth'
+import { useVaultSummary } from '@/hooks/use-analytics'
+import { useUserProfile } from '@/hooks/use-user-profile'
+import { VaultMetricCard } from './vault-metric-card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+function formatVolume(volumeLb: number, isMetric: boolean): string {
+  if (isMetric) {
+    const kg = Math.round(volumeLb / 2.205)
+    return `${kg.toLocaleString()} kg`
+  }
+  return `${Math.round(volumeLb).toLocaleString()} lb`
+}
+
+export function VaultOverview() {
+  const { user } = useAuth()
+  const userId = user?.id
+  const { data: profile } = useUserProfile(userId ?? '')
+  const { data: summary, isLoading, isError } = useVaultSummary(userId)
+
+  const isMetric = profile?.preferredUnits === 'METRIC'
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 gap-4 pt-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-28 rounded-none bg-surface-steel" />
+        ))}
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <p className="font-display text-sm text-warning-flare">Failed to load analytics</p>
+      </div>
+    )
+  }
+
+  if (!summary) {
+    return null
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4 pt-4">
+      <VaultMetricCard label="WORKOUTS" value={summary.totalWorkouts} />
+      <VaultMetricCard label="VOLUME" value={formatVolume(summary.totalVolumeLb, isMetric)} />
+      <VaultMetricCard label="THIS WEEK" value={summary.thisWeekWorkouts} />
+      <VaultMetricCard
+        label="THIS WEEK VOL"
+        value={formatVolume(summary.thisWeekVolumeLb, isMetric)}
+      />
+    </div>
+  )
+}

--- a/src/components/vault/vault-volume-tab.tsx
+++ b/src/components/vault/vault-volume-tab.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { useAuth } from '@/lib/auth'
+import { useExercises } from '@/hooks/use-exercises'
+import { useWeeklyVolume } from '@/hooks/use-analytics'
+import { VolumeLoadBar } from '@/components/history/volume-load-bar'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function VaultVolumeTab() {
+  const { user } = useAuth()
+  const userId = user?.id
+  const { data: exercises, isLoading: isLoadingExercises } = useExercises()
+  const [selectedExerciseId, setSelectedExerciseId] = useState<string | undefined>(undefined)
+
+  const { data: volumeData, isLoading: isLoadingVolume } = useWeeklyVolume(
+    userId,
+    selectedExerciseId,
+    8,
+  )
+
+  const maxTonnage = volumeData ? Math.max(...volumeData.map((e) => e.tonnage)) : 0
+
+  if (isLoadingExercises) {
+    return (
+      <div className="space-y-4 pt-4">
+        <Skeleton className="h-10 w-full rounded-none bg-surface-steel" />
+        <Skeleton className="h-64 w-full rounded-none bg-surface-steel" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 pt-4">
+      <Select
+        value={selectedExerciseId ?? ''}
+        onValueChange={(val) => setSelectedExerciseId(val || undefined)}
+      >
+        <SelectTrigger className="min-h-12 w-full border-surface-steel bg-surface-iron font-body text-sm text-bone-white">
+          <SelectValue placeholder="Select an exercise" />
+        </SelectTrigger>
+        <SelectContent className="bg-surface-iron">
+          {(exercises ?? []).map((exercise) => (
+            <SelectItem key={exercise.id} value={exercise.id}>
+              {exercise.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {!selectedExerciseId && (
+        <div className="flex items-center justify-center bg-surface-iron p-8">
+          <p className="font-display text-sm text-warm-ash">
+            Select an exercise to view volume trends
+          </p>
+        </div>
+      )}
+
+      {selectedExerciseId && isLoadingVolume && (
+        <div className="space-y-3 pt-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-6 w-full rounded-none bg-surface-steel" />
+          ))}
+        </div>
+      )}
+
+      {selectedExerciseId && !isLoadingVolume && volumeData && volumeData.length > 0 && (
+        <div className="space-y-3 pt-2">
+          {volumeData.map((entry) => (
+            <div key={entry.weekStart} className="flex items-center gap-3">
+              <div className="flex-1">
+                <VolumeLoadBar
+                  label={entry.weekLabel}
+                  value={entry.tonnage}
+                  maxValue={maxTonnage}
+                />
+              </div>
+              <span className="w-24 shrink-0 text-right font-body text-xs tabular-nums text-warm-ash">
+                {entry.tonnage.toLocaleString()} {entry.unit}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {selectedExerciseId && !isLoadingVolume && (!volumeData || volumeData.length === 0) && (
+        <div className="flex items-center justify-center bg-surface-iron p-8">
+          <p className="font-display text-sm text-warm-ash">No volume history for this exercise</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/workout/pr-banner.tsx
+++ b/src/components/workout/pr-banner.tsx
@@ -1,0 +1,78 @@
+import type React from 'react'
+import type { PersonalRecord } from '@/domain/types'
+
+function riseDelay(seconds: number): React.CSSProperties {
+  return { animation: `rise 0.4s ease-out ${seconds}s both` }
+}
+
+/**
+ * Derive the rep count label from the PersonalRecord type.
+ * - 1RM -> 1
+ * - 3RM -> 3
+ * - 5RM -> 5
+ */
+function repsFromType(type: PersonalRecord['type']): number | null {
+  switch (type) {
+    case '1RM':
+      return 1
+    case '3RM':
+      return 3
+    case '5RM':
+      return 5
+    default:
+      return null
+  }
+}
+
+function formatPrLine(record: PersonalRecord): string {
+  const name = record.exerciseName.toUpperCase()
+
+  // Strength PRs: show weight x reps
+  const reps = repsFromType(record.type)
+  if (reps !== null) {
+    return `NEW PR: ${name} -- ${record.value}${record.unit} x ${reps}`
+  }
+
+  // Max-reps PRs: show rep count
+  if (record.type === 'max-reps') {
+    return `NEW PR: ${name} -- ${record.value} REPS`
+  }
+
+  // Cardio PRs: show value + unit
+  return `NEW PR: ${name} -- ${record.value}${record.unit}`
+}
+
+interface PrBannerProps {
+  records: PersonalRecord[]
+}
+
+export function PrBanner({ records }: PrBannerProps) {
+  if (records.length === 0) return null
+
+  return (
+    <div
+      className="mb-8 px-4 py-4"
+      style={{
+        background: 'linear-gradient(135deg, #FFB59C 0%, #FB5C1C 100%)',
+        color: '#511500',
+        borderRadius: '0px',
+        ...riseDelay(0.55),
+      }}
+    >
+      <span className="font-body text-[11px] uppercase tracking-widest block mb-2">
+        Personal Records
+      </span>
+      <div className="flex flex-col gap-1.5">
+        {records.map((record, i) => (
+          <p
+            key={`${record.exerciseId}-${record.type}`}
+            className="font-body text-sm font-semibold leading-snug"
+            style={riseDelay(0.6 + i * 0.06)}
+          >
+            {formatPrLine(record)}
+          </p>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/workout/workout-summary.tsx
+++ b/src/components/workout/workout-summary.tsx
@@ -1,8 +1,9 @@
 import type React from 'react'
 import { useMemo, useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { PrBanner } from './pr-banner'
 import { formatDuration } from '@/lib/format-duration'
-import type { Weight, WorkoutLog, ProgramContext } from '@/domain/types'
+import type { Weight, WorkoutLog, ProgramContext, PersonalRecord } from '@/domain/types'
 import type {
   LoggedActivityGroupWithActivities,
   LoggedActivityWithSets,
@@ -17,6 +18,8 @@ interface WorkoutSummaryProps {
   programName?: string
   /** Block name shown in the session context line above the heading */
   blockName?: string
+  /** Detected personal records to celebrate in the summary */
+  personalRecords?: PersonalRecord[]
 }
 
 interface ExerciseSummary {
@@ -71,6 +74,7 @@ export function WorkoutSummary({
   onDone,
   programName,
   blockName,
+  personalRecords,
 }: WorkoutSummaryProps) {
   const programContext: ProgramContext | undefined = workoutLog.programContext ?? undefined
 
@@ -226,6 +230,9 @@ export function WorkoutSummary({
             </>
           )}
         </div>
+
+        {/* PR celebration banner */}
+        <PrBanner records={personalRecords ?? []} />
 
         {/* Secondary stats — asymmetric sizes, left-aligned */}
         <div className="mb-8 flex items-end gap-6" style={riseDelay(0.62)}>

--- a/src/domain/types/analytics.ts
+++ b/src/domain/types/analytics.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// PersonalRecordType -- classification of a personal record
+// ---------------------------------------------------------------------------
+
+export const PersonalRecordTypeSchema = z.enum([
+  '1RM',
+  '3RM',
+  '5RM',
+  'max-reps',
+  'cardio-distance',
+  'cardio-duration',
+])
+export type PersonalRecordType = z.infer<typeof PersonalRecordTypeSchema>
+
+// ---------------------------------------------------------------------------
+// PersonalRecord -- a detected personal record from a workout
+// ---------------------------------------------------------------------------
+
+export const PersonalRecordSchema = z.object({
+  exerciseId: z.string(),
+  exerciseName: z.string(),
+  type: PersonalRecordTypeSchema,
+  value: z.number(),
+  unit: z.string(),
+  previousBest: z.number().nullable(),
+  workoutLogId: z.string(),
+})
+export type PersonalRecord = z.infer<typeof PersonalRecordSchema>
+
+// ---------------------------------------------------------------------------
+// WeeklyVolumeEntry -- aggregated volume data for one week
+// ---------------------------------------------------------------------------
+
+export const WeeklyVolumeEntrySchema = z.object({
+  weekLabel: z.string(),
+  weekStart: z.string(),
+  tonnage: z.number(),
+  unit: z.enum(['lb', 'kg']),
+})
+export type WeeklyVolumeEntry = z.infer<typeof WeeklyVolumeEntrySchema>

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -34,6 +34,7 @@ export type {
 export * from './workout-log'
 export * from './user'
 export * from './sharing'
+export * from './analytics'
 
 // program.ts re-exports sessionTypeSchema and SessionType from session.ts.
 // Exclude those names here to prevent ambiguous re-export errors.

--- a/src/hooks/use-analytics.ts
+++ b/src/hooks/use-analytics.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query'
+import { getAdapter } from '@/lib/adapter'
+import type { WeeklyVolumeEntry } from '@/domain/types'
+import type { VaultSummary } from '@/lib/data-adapter'
+
+export function useWeeklyVolume(
+  userId: string | undefined,
+  exerciseId: string | undefined,
+  weeks = 8,
+) {
+  return useQuery<WeeklyVolumeEntry[]>({
+    queryKey: ['weeklyVolume', userId, exerciseId, weeks],
+    queryFn: () => getAdapter().getWeeklyVolume(userId!, exerciseId!, weeks),
+    enabled: !!userId && !!exerciseId,
+  })
+}
+
+export function useVaultSummary(userId: string | undefined) {
+  return useQuery<VaultSummary>({
+    queryKey: ['vaultSummary', userId],
+    queryFn: () => getAdapter().getVaultSummary(userId!),
+    enabled: !!userId,
+  })
+}

--- a/src/lib/__tests__/pr-detection.test.ts
+++ b/src/lib/__tests__/pr-detection.test.ts
@@ -1,0 +1,306 @@
+import { detectPersonalRecords } from '../pr-detection'
+import type { WorkoutLog, LoggedActivity, LoggedSet, UserProfile } from '@/domain/types'
+
+// ---------------------------------------------------------------------------
+// Helpers -- minimal valid objects for test setup
+// ---------------------------------------------------------------------------
+
+const now = new Date().toISOString()
+
+function makeWorkoutLog(overrides?: Partial<WorkoutLog>): WorkoutLog {
+  return {
+    id: 'wl-1',
+    userId: 'user-1',
+    startedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  } as WorkoutLog
+}
+
+function makeActivity(overrides?: Partial<LoggedActivity>): LoggedActivity {
+  return {
+    id: 'la-1',
+    loggedGroupId: 'lag-1',
+    exerciseId: 'ex-bench',
+    ordinal: 1,
+    ...overrides,
+  }
+}
+
+function makeSet(overrides?: Partial<LoggedSet>): LoggedSet {
+  return {
+    id: 'ls-1',
+    loggedActivityId: 'la-1',
+    setNumber: 1,
+    setType: 'WORKING',
+    completed: true,
+    ...overrides,
+  } as LoggedSet
+}
+
+function makeUserProfile(overrides?: Partial<UserProfile>): UserProfile {
+  return {
+    id: 'user-1',
+    exerciseMaxes: {},
+    maxReps: {},
+    preferredUnits: 'IMPERIAL',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  } as UserProfile
+}
+
+const exerciseNames: Record<string, string> = {
+  'ex-bench': 'Bench Press',
+  'ex-pullup': 'Pull-up',
+  'ex-squat': 'Back Squat',
+}
+
+// ===========================================================================
+// detectPersonalRecords
+// ===========================================================================
+
+describe('detectPersonalRecords', () => {
+  it('returns empty array when sets array is empty', () => {
+    const result = detectPersonalRecords(
+      { log: makeWorkoutLog(), groups: [], activities: [makeActivity()], sets: [] },
+      makeUserProfile(),
+      exerciseNames,
+    )
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array when new best equals existing (not strictly greater)', () => {
+    const profile = makeUserProfile({
+      exerciseMaxes: {
+        'ex-bench': { weight: { value: 225, unit: 'lb' }, testedAt: now, estimated: false },
+      },
+    })
+    const sets = [
+      makeSet({
+        actualReps: 1,
+        actualWeight: { value: 225, unit: 'lb' },
+      }),
+    ]
+    const result = detectPersonalRecords(
+      { log: makeWorkoutLog(), groups: [], activities: [makeActivity()], sets },
+      profile,
+      exerciseNames,
+    )
+    // 225 === 225, not strictly greater, so no 1RM PR
+    const oneRm = result.find((r) => r.type === '1RM')
+    expect(oneRm).toBeUndefined()
+  })
+
+  it('returns 1RM PR when heaviest single exceeds current exercise max', () => {
+    const profile = makeUserProfile({
+      exerciseMaxes: {
+        'ex-bench': { weight: { value: 225, unit: 'lb' }, testedAt: now, estimated: false },
+      },
+    })
+    const sets = [
+      makeSet({
+        id: 'ls-1',
+        actualReps: 1,
+        actualWeight: { value: 230, unit: 'lb' },
+      }),
+      makeSet({
+        id: 'ls-2',
+        setNumber: 2,
+        actualReps: 1,
+        actualWeight: { value: 215, unit: 'lb' },
+      }),
+    ]
+    const result = detectPersonalRecords(
+      { log: makeWorkoutLog(), groups: [], activities: [makeActivity()], sets },
+      profile,
+      exerciseNames,
+    )
+    const oneRm = result.find((r) => r.type === '1RM')
+    expect(oneRm).toBeDefined()
+    expect(oneRm!.value).toBe(230)
+    expect(oneRm!.previousBest).toBe(225)
+    expect(oneRm!.exerciseName).toBe('Bench Press')
+  })
+
+  it('returns 5RM PR when heaviest 5-rep set is found', () => {
+    const sets = [
+      makeSet({
+        actualReps: 5,
+        actualWeight: { value: 185, unit: 'lb' },
+      }),
+    ]
+    const result = detectPersonalRecords(
+      { log: makeWorkoutLog(), groups: [], activities: [makeActivity()], sets },
+      makeUserProfile(),
+      exerciseNames,
+    )
+    const fiveRm = result.find((r) => r.type === '5RM')
+    expect(fiveRm).toBeDefined()
+    expect(fiveRm!.value).toBe(185)
+    expect(fiveRm!.previousBest).toBeNull()
+  })
+
+  it('does not return PR from WARMUP sets', () => {
+    const sets = [
+      makeSet({
+        setType: 'WARMUP',
+        actualReps: 1,
+        actualWeight: { value: 500, unit: 'lb' },
+      }),
+    ]
+    const result = detectPersonalRecords(
+      { log: makeWorkoutLog(), groups: [], activities: [makeActivity()], sets },
+      makeUserProfile(),
+      exerciseNames,
+    )
+    expect(result).toEqual([])
+  })
+
+  it('does not return PR from DROP sets', () => {
+    const sets = [
+      makeSet({
+        setType: 'DROP',
+        actualReps: 1,
+        actualWeight: { value: 500, unit: 'lb' },
+      }),
+    ]
+    const result = detectPersonalRecords(
+      { log: makeWorkoutLog(), groups: [], activities: [makeActivity()], sets },
+      makeUserProfile(),
+      exerciseNames,
+    )
+    expect(result).toEqual([])
+  })
+
+  it('handles exercises with no existing max (previousBest = null, still returns PR)', () => {
+    const profile = makeUserProfile({ exerciseMaxes: {} })
+    const sets = [
+      makeSet({
+        actualReps: 1,
+        actualWeight: { value: 135, unit: 'lb' },
+      }),
+    ]
+    const result = detectPersonalRecords(
+      { log: makeWorkoutLog(), groups: [], activities: [makeActivity()], sets },
+      profile,
+      exerciseNames,
+    )
+    const oneRm = result.find((r) => r.type === '1RM')
+    expect(oneRm).toBeDefined()
+    expect(oneRm!.value).toBe(135)
+    expect(oneRm!.previousBest).toBeNull()
+  })
+
+  it('handles workout with no exerciseMaxes in profile', () => {
+    // UserProfile where exerciseMaxes is an empty object
+    const profile = makeUserProfile()
+    const sets = [
+      makeSet({
+        actualReps: 1,
+        actualWeight: { value: 315, unit: 'lb' },
+      }),
+    ]
+    const result = detectPersonalRecords(
+      { log: makeWorkoutLog(), groups: [], activities: [makeActivity()], sets },
+      profile,
+      exerciseNames,
+    )
+    const oneRm = result.find((r) => r.type === '1RM')
+    expect(oneRm).toBeDefined()
+    expect(oneRm!.value).toBe(315)
+    expect(oneRm!.previousBest).toBeNull()
+  })
+
+  it('detects max-reps PR for bodyweight exercises', () => {
+    const activity = makeActivity({ exerciseId: 'ex-pullup' })
+    const sets = [
+      makeSet({
+        loggedActivityId: activity.id,
+        actualReps: 15,
+        // no actualWeight -- bodyweight exercise
+      }),
+    ]
+    const profile = makeUserProfile({ maxReps: { 'ex-pullup': 12 } })
+    const result = detectPersonalRecords(
+      { log: makeWorkoutLog(), groups: [], activities: [activity], sets },
+      profile,
+      exerciseNames,
+    )
+    const maxReps = result.find((r) => r.type === 'max-reps')
+    expect(maxReps).toBeDefined()
+    expect(maxReps!.value).toBe(15)
+    expect(maxReps!.previousBest).toBe(12)
+    expect(maxReps!.unit).toBe('reps')
+  })
+
+  it('does not return max-reps PR when reps equal existing max', () => {
+    const activity = makeActivity({ exerciseId: 'ex-pullup' })
+    const sets = [
+      makeSet({
+        loggedActivityId: activity.id,
+        actualReps: 12,
+      }),
+    ]
+    const profile = makeUserProfile({ maxReps: { 'ex-pullup': 12 } })
+    const result = detectPersonalRecords(
+      { log: makeWorkoutLog(), groups: [], activities: [activity], sets },
+      profile,
+      exerciseNames,
+    )
+    const maxReps = result.find((r) => r.type === 'max-reps')
+    expect(maxReps).toBeUndefined()
+  })
+
+  it('skips incomplete sets', () => {
+    const sets = [
+      makeSet({
+        completed: false,
+        actualReps: 1,
+        actualWeight: { value: 500, unit: 'lb' },
+      }),
+    ]
+    const result = detectPersonalRecords(
+      { log: makeWorkoutLog(), groups: [], activities: [makeActivity()], sets },
+      makeUserProfile(),
+      exerciseNames,
+    )
+    expect(result).toEqual([])
+  })
+
+  it('handles multiple exercises in same workout', () => {
+    const benchActivity = makeActivity({ id: 'la-bench', exerciseId: 'ex-bench' })
+    const squatActivity = makeActivity({ id: 'la-squat', exerciseId: 'ex-squat' })
+    const sets = [
+      makeSet({
+        loggedActivityId: 'la-bench',
+        actualReps: 1,
+        actualWeight: { value: 225, unit: 'lb' },
+      }),
+      makeSet({
+        id: 'ls-2',
+        loggedActivityId: 'la-squat',
+        setNumber: 1,
+        actualReps: 1,
+        actualWeight: { value: 315, unit: 'lb' },
+      }),
+    ]
+    const result = detectPersonalRecords(
+      {
+        log: makeWorkoutLog(),
+        groups: [],
+        activities: [benchActivity, squatActivity],
+        sets,
+      },
+      makeUserProfile(),
+      exerciseNames,
+    )
+    const benchPr = result.find((r) => r.exerciseId === 'ex-bench' && r.type === '1RM')
+    const squatPr = result.find((r) => r.exerciseId === 'ex-squat' && r.type === '1RM')
+    expect(benchPr).toBeDefined()
+    expect(squatPr).toBeDefined()
+    expect(benchPr!.value).toBe(225)
+    expect(squatPr!.value).toBe(315)
+  })
+})

--- a/src/lib/data-adapter.ts
+++ b/src/lib/data-adapter.ts
@@ -16,6 +16,7 @@ import type {
   ProgramActivation,
 } from '@/domain/types'
 import type { ExerciseCategory, MovementPattern, MuscleGroup } from '@/domain/types'
+import type { WeeklyVolumeEntry } from '@/domain/types'
 
 export type WorkoutWithSets = { log: WorkoutLog; sets: LoggedSet[] }
 
@@ -37,6 +38,13 @@ export type ProgramFull = {
   blocks: Block[]
   blockWeeks: BlockWeek[]
   scheduledSessions: ScheduledSession[]
+}
+
+export type VaultSummary = {
+  totalWorkouts: number
+  totalVolumeLb: number
+  thisWeekWorkouts: number
+  thisWeekVolumeLb: number
 }
 
 export interface ExerciseFilters {
@@ -169,4 +177,12 @@ export interface DataAdapter {
     updates: { currentBlockOrdinal?: number; currentWeekNumber?: number },
   ): Promise<ProgramActivation>
   clearActiveProgram(userId: string): Promise<void>
+
+  // Analytics operations
+
+  /** Returns weekly volume (tonnage) for an exercise over the last N weeks. */
+  getWeeklyVolume(userId: string, exerciseId: string, weeks?: number): Promise<WeeklyVolumeEntry[]>
+
+  /** Returns aggregate workout and volume stats for the vault summary card. */
+  getVaultSummary(userId: string): Promise<VaultSummary>
 }

--- a/src/lib/pr-detection.ts
+++ b/src/lib/pr-detection.ts
@@ -1,0 +1,153 @@
+import type {
+  WorkoutLog,
+  LoggedActivityGroup,
+  LoggedActivity,
+  LoggedSet,
+  UserProfile,
+  PersonalRecord,
+} from '@/domain/types'
+
+/**
+ * Detects personal records from a completed workout by comparing the actual
+ * performance against the user's stored exercise maxes and max reps.
+ *
+ * Detection rules:
+ * - Only completed sets are considered (warmup and drop sets are excluded)
+ * - 1RM: heaviest weight where actualReps === 1, must exceed stored exerciseMaxes
+ * - 3RM: heaviest weight where actualReps >= 3
+ * - 5RM: heaviest weight where actualReps >= 5
+ * - max-reps: highest actualReps on a bodyweight exercise, must exceed stored maxReps
+ *
+ * For 3RM/5RM, previousBest is always null since we don't track those separately.
+ * For 1RM, previousBest comes from userProfile.exerciseMaxes.
+ * For max-reps, previousBest comes from userProfile.maxReps.
+ */
+export function detectPersonalRecords(
+  workout: {
+    log: WorkoutLog
+    groups: LoggedActivityGroup[]
+    activities: LoggedActivity[]
+    sets: LoggedSet[]
+  },
+  userProfile: UserProfile,
+  exerciseNames: Record<string, string>,
+): PersonalRecord[] {
+  const { log, activities, sets } = workout
+
+  // Build a lookup from loggedActivityId -> exerciseId
+  const activityExerciseMap = new Map<string, string>()
+  for (const activity of activities) {
+    activityExerciseMap.set(activity.id, activity.exerciseId)
+  }
+
+  // Filter to only completed working sets (exclude WARMUP and DROP)
+  const qualifyingSets = sets.filter(
+    (s) => s.completed && s.setType !== 'WARMUP' && s.setType !== 'DROP',
+  )
+
+  // Group qualifying sets by exerciseId
+  const setsByExercise = new Map<string, LoggedSet[]>()
+  for (const set of qualifyingSets) {
+    const exerciseId = activityExerciseMap.get(set.loggedActivityId)
+    if (!exerciseId) continue
+
+    const existing = setsByExercise.get(exerciseId)
+    if (existing) {
+      existing.push(set)
+    } else {
+      setsByExercise.set(exerciseId, [set])
+    }
+  }
+
+  const records: PersonalRecord[] = []
+
+  for (const [exerciseId, exerciseSets] of setsByExercise) {
+    const exerciseName = exerciseNames[exerciseId] ?? 'Unknown Exercise'
+    const storedMax = userProfile.exerciseMaxes?.[exerciseId]
+    const storedMaxReps = userProfile.maxReps?.[exerciseId]
+
+    // -- 1RM detection: heaviest weight where actualReps === 1 --
+    const singleRepSets = exerciseSets.filter((s) => s.actualReps === 1 && s.actualWeight != null)
+    if (singleRepSets.length > 0) {
+      const best1RM = singleRepSets.reduce((max, s) =>
+        s.actualWeight!.value > max.actualWeight!.value ? s : max,
+      )
+      const previousBest = storedMax?.weight?.value ?? null
+      // Only record as PR if it exceeds the stored max (or no stored max exists)
+      if (previousBest === null || best1RM.actualWeight!.value > previousBest) {
+        records.push({
+          exerciseId,
+          exerciseName,
+          type: '1RM',
+          value: best1RM.actualWeight!.value,
+          unit: best1RM.actualWeight!.unit,
+          previousBest,
+          workoutLogId: log.id,
+        })
+      }
+    }
+
+    // -- 3RM detection: heaviest weight where actualReps >= 3 --
+    const threeRepSets = exerciseSets.filter(
+      (s) => s.actualReps != null && s.actualReps >= 3 && s.actualWeight != null,
+    )
+    if (threeRepSets.length > 0) {
+      const best3RM = threeRepSets.reduce((max, s) =>
+        s.actualWeight!.value > max.actualWeight!.value ? s : max,
+      )
+      records.push({
+        exerciseId,
+        exerciseName,
+        type: '3RM',
+        value: best3RM.actualWeight!.value,
+        unit: best3RM.actualWeight!.unit,
+        previousBest: null,
+        workoutLogId: log.id,
+      })
+    }
+
+    // -- 5RM detection: heaviest weight where actualReps >= 5 --
+    const fiveRepSets = exerciseSets.filter(
+      (s) => s.actualReps != null && s.actualReps >= 5 && s.actualWeight != null,
+    )
+    if (fiveRepSets.length > 0) {
+      const best5RM = fiveRepSets.reduce((max, s) =>
+        s.actualWeight!.value > max.actualWeight!.value ? s : max,
+      )
+      records.push({
+        exerciseId,
+        exerciseName,
+        type: '5RM',
+        value: best5RM.actualWeight!.value,
+        unit: best5RM.actualWeight!.unit,
+        previousBest: null,
+        workoutLogId: log.id,
+      })
+    }
+
+    // -- max-reps detection: highest reps on bodyweight exercise (no weight) --
+    const bodyweightSets = exerciseSets.filter(
+      (s) => s.actualReps != null && s.actualWeight == null,
+    )
+    if (bodyweightSets.length > 0) {
+      const bestReps = bodyweightSets.reduce((max, s) =>
+        s.actualReps! > max.actualReps! ? s : max,
+      )
+      const previousBest = storedMaxReps ?? null
+      // Only record as PR if it exceeds the stored max reps (or no stored value exists)
+      if (previousBest === null || bestReps.actualReps! > previousBest) {
+        records.push({
+          exerciseId,
+          exerciseName,
+          type: 'max-reps',
+          value: bestReps.actualReps!,
+          unit: 'reps',
+          previousBest,
+          workoutLogId: log.id,
+        })
+      }
+    }
+  }
+
+  return records
+}

--- a/src/lib/supabase-adapter.ts
+++ b/src/lib/supabase-adapter.ts
@@ -4,6 +4,7 @@ import type {
   ExerciseFilters,
   ProgramFull,
   SessionTemplateFull,
+  VaultSummary,
   WorkoutLogSummary,
 } from './data-adapter'
 import type {
@@ -22,6 +23,7 @@ import type {
   BlockWeek,
   ScheduledSession,
   ProgramActivation,
+  WeeklyVolumeEntry,
 } from '@/domain/types'
 import type {
   ExerciseRow,
@@ -1004,4 +1006,184 @@ export class SupabaseAdapter implements DataAdapter {
     const { error } = await this.client.from('program_activations').delete().eq('user_id', userId)
     if (error) throw error
   }
+
+  // ---------------------------------------------------------------------------
+  // Analytics operations
+  // ---------------------------------------------------------------------------
+
+  async getWeeklyVolume(
+    userId: string,
+    exerciseId: string,
+    weeks = 8,
+  ): Promise<WeeklyVolumeEntry[]> {
+    // Supabase JS client cannot express multi-table JOINs with aggregation via
+    // the query builder. Instead, fetch the nested data and aggregate in TS.
+    // This matches the offline-first data adapter pattern used elsewhere.
+    const { data, error } = await this.client
+      .from('logged_activities')
+      .select(
+        'id, exercise_id, logged_activity_groups!inner(workout_log_id, workout_logs!inner(started_at, completed_at, user_id)), logged_sets(actual_weight, actual_reps, completed)',
+      )
+      .eq('exercise_id', exerciseId)
+      .eq('logged_activity_groups.workout_logs.user_id', userId)
+      .not('logged_activity_groups.workout_logs.completed_at', 'is', null)
+
+    if (error) throw error
+
+    type VolumeRow = {
+      id: string
+      exercise_id: string
+      logged_activity_groups: {
+        workout_log_id: string
+        workout_logs: {
+          started_at: string
+          completed_at: string | null
+          user_id: string
+        }
+      }
+      logged_sets: Array<{
+        actual_weight: { value: number; unit: string } | null
+        actual_reps: number | null
+        completed: boolean
+      }>
+    }
+    const rows = data as unknown as VolumeRow[]
+
+    // Aggregate by ISO week
+    const weekMap = new Map<string, { label: string; tonnage: number; unit: 'lb' | 'kg' }>()
+
+    for (const row of rows) {
+      const startedAt = new Date(row.logged_activity_groups.workout_logs.started_at)
+      const weekStart = getMonday(startedAt)
+      const weekKey = weekStart.toISOString().slice(0, 10)
+
+      for (const set of row.logged_sets) {
+        if (!set.completed || set.actual_weight == null || set.actual_reps == null) continue
+
+        const tonnage = set.actual_weight.value * set.actual_reps
+        const existing = weekMap.get(weekKey)
+        if (existing) {
+          existing.tonnage += tonnage
+          // Use the unit from the first set seen in this week
+        } else {
+          const label = formatWeekLabel(weekStart)
+          weekMap.set(weekKey, {
+            label,
+            tonnage,
+            unit: set.actual_weight.unit as 'lb' | 'kg',
+          })
+        }
+      }
+    }
+
+    // Sort descending by week and limit
+    return Array.from(weekMap.entries())
+      .sort(([a], [b]) => b.localeCompare(a))
+      .slice(0, weeks)
+      .reverse()
+      .map(([weekStart, entry]) => ({
+        weekLabel: entry.label,
+        weekStart,
+        tonnage: Math.round(entry.tonnage),
+        unit: entry.unit,
+      }))
+  }
+
+  async getVaultSummary(userId: string): Promise<VaultSummary> {
+    // Fetch all completed workout logs with nested sets for volume calculation
+    const { data, error } = await this.client
+      .from('workout_logs')
+      .select(
+        'id, started_at, logged_activity_groups(logged_activities(logged_sets(actual_weight, actual_reps, completed)))',
+      )
+      .eq('user_id', userId)
+      .not('completed_at', 'is', null)
+
+    if (error) throw error
+
+    type SummaryRow = {
+      id: string
+      started_at: string
+      logged_activity_groups: Array<{
+        logged_activities: Array<{
+          logged_sets: Array<{
+            actual_weight: { value: number; unit: string } | null
+            actual_reps: number | null
+            completed: boolean
+          }>
+        }>
+      }>
+    }
+    const rows = data as unknown as SummaryRow[]
+
+    const monday = getMonday(new Date())
+
+    let totalWorkouts = 0
+    let totalVolumeLb = 0
+    let thisWeekWorkouts = 0
+    let thisWeekVolumeLb = 0
+
+    for (const row of rows) {
+      totalWorkouts++
+      const isThisWeek = new Date(row.started_at) >= monday
+      if (isThisWeek) thisWeekWorkouts++
+
+      for (const group of row.logged_activity_groups) {
+        for (const activity of group.logged_activities) {
+          for (const set of activity.logged_sets) {
+            if (!set.completed || set.actual_weight == null || set.actual_reps == null) continue
+
+            let weightLb = set.actual_weight.value
+            if (set.actual_weight.unit === 'kg') {
+              weightLb = set.actual_weight.value * 2.20462
+            }
+            const volume = weightLb * set.actual_reps
+            totalVolumeLb += volume
+            if (isThisWeek) thisWeekVolumeLb += volume
+          }
+        }
+      }
+    }
+
+    return {
+      totalWorkouts,
+      totalVolumeLb: Math.round(totalVolumeLb),
+      thisWeekWorkouts,
+      thisWeekVolumeLb: Math.round(thisWeekVolumeLb),
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns the Monday at 00:00 UTC of the week containing the given date. */
+function getMonday(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getUTCDay()
+  // Sunday = 0, Monday = 1, ..., Saturday = 6
+  const diff = day === 0 ? 6 : day - 1
+  d.setUTCDate(d.getUTCDate() - diff)
+  d.setUTCHours(0, 0, 0, 0)
+  return d
+}
+
+/** Formats a date as "Mon DD" (e.g. "Mar 24"). */
+function formatWeekLabel(date: Date): string {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ]
+  return `${months[date.getUTCMonth()]} ${String(date.getUTCDate()).padStart(2, '0')}`
 }

--- a/src/lib/tauri-adapter.ts
+++ b/src/lib/tauri-adapter.ts
@@ -4,6 +4,7 @@ import type {
   ExerciseFilters,
   ProgramFull,
   SessionTemplateFull,
+  VaultSummary,
   WorkoutLogSummary,
   WorkoutWithSets,
 } from './data-adapter'
@@ -23,6 +24,7 @@ import type {
   BlockWeek,
   ScheduledSession,
   ProgramActivation,
+  WeeklyVolumeEntry,
 } from '@/domain/types'
 import type {
   ExerciseRow,
@@ -1384,4 +1386,130 @@ export class TauriAdapter implements DataAdapter {
   async clearActiveProgram(userId: string): Promise<void> {
     await invokeCommand<void>('clear_active_program', { user_id: userId })
   }
+
+  // ---------------------------------------------------------------------------
+  // Analytics operations
+  // ---------------------------------------------------------------------------
+
+  async getWeeklyVolume(
+    userId: string,
+    exerciseId: string,
+    weeks = 8,
+  ): Promise<WeeklyVolumeEntry[]> {
+    // No dedicated Rust command exists yet, so fetch exercise workout history
+    // and aggregate tonnage by week in TypeScript.
+    // Use a generous limit to capture enough weeks of data.
+    const history = await this.getExerciseWorkoutHistory(userId, exerciseId, weeks * 7)
+
+    const weekMap = new Map<string, { label: string; tonnage: number; unit: 'lb' | 'kg' }>()
+
+    for (const { log, sets } of history) {
+      const startedAt = new Date(log.startedAt)
+      const weekStart = getMonday(startedAt)
+      const weekKey = weekStart.toISOString().slice(0, 10)
+
+      for (const set of sets) {
+        if (!set.completed || set.actualWeight == null || set.actualReps == null) continue
+
+        const tonnage = set.actualWeight.value * set.actualReps
+        const existing = weekMap.get(weekKey)
+        if (existing) {
+          existing.tonnage += tonnage
+        } else {
+          const label = formatWeekLabel(weekStart)
+          weekMap.set(weekKey, {
+            label,
+            tonnage,
+            unit: set.actualWeight.unit,
+          })
+        }
+      }
+    }
+
+    return Array.from(weekMap.entries())
+      .sort(([a], [b]) => b.localeCompare(a))
+      .slice(0, weeks)
+      .reverse()
+      .map(([weekStart, entry]) => ({
+        weekLabel: entry.label,
+        weekStart,
+        tonnage: Math.round(entry.tonnage),
+        unit: entry.unit,
+      }))
+  }
+
+  async getVaultSummary(userId: string): Promise<VaultSummary> {
+    // Fetch all completed workout logs and compute stats client-side.
+    const logs = await this.getWorkoutLogs(userId)
+    const completedLogs = logs.filter((l) => l.completedAt != null)
+
+    const monday = getMonday(new Date())
+
+    let totalWorkouts = 0
+    let totalVolumeLb = 0
+    let thisWeekWorkouts = 0
+    let thisWeekVolumeLb = 0
+
+    for (const log of completedLogs) {
+      totalWorkouts++
+      const isThisWeek = new Date(log.startedAt) >= monday
+      if (isThisWeek) thisWeekWorkouts++
+
+      // Fetch full workout data to calculate volume
+      const full = await this.getWorkoutLogFull(log.id)
+      if (!full) continue
+
+      for (const set of full.sets) {
+        if (!set.completed || set.actualWeight == null || set.actualReps == null) continue
+
+        let weightLb = set.actualWeight.value
+        if (set.actualWeight.unit === 'kg') {
+          weightLb = set.actualWeight.value * 2.20462
+        }
+        const volume = weightLb * set.actualReps
+        totalVolumeLb += volume
+        if (isThisWeek) thisWeekVolumeLb += volume
+      }
+    }
+
+    return {
+      totalWorkouts,
+      totalVolumeLb: Math.round(totalVolumeLb),
+      thisWeekWorkouts,
+      thisWeekVolumeLb: Math.round(thisWeekVolumeLb),
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns the Monday at 00:00 UTC of the week containing the given date. */
+function getMonday(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getUTCDay()
+  const diff = day === 0 ? 6 : day - 1
+  d.setUTCDate(d.getUTCDate() - diff)
+  d.setUTCHours(0, 0, 0, 0)
+  return d
+}
+
+/** Formats a date as "Mon DD" (e.g. "Mar 24"). */
+function formatWeekLabel(date: Date): string {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ]
+  return `${months[date.getUTCMonth()]} ${String(date.getUTCDate()).padStart(2, '0')}`
 }

--- a/src/routes/_authenticated/exercises/$exerciseId.tsx
+++ b/src/routes/_authenticated/exercises/$exerciseId.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -55,6 +55,31 @@ function ExerciseDetailPage() {
 
   const currentOneRm = profile?.exerciseMaxes?.[exerciseId]
   const weightUnit = profile?.preferredUnits === 'METRIC' ? 'kg' : 'lb'
+
+  const { threeRepMax, fiveRepMax } = useMemo(() => {
+    let threeRepMax: number | null = null
+    let fiveRepMax: number | null = null
+    if (!workoutHistory) return { threeRepMax, fiveRepMax }
+
+    for (const entry of workoutHistory) {
+      for (const set of entry.sets) {
+        if (!set.completed) continue
+        if (set.setType === 'WARMUP' || set.setType === 'DROP') continue
+        if (set.actualWeight?.value == null || set.actualReps == null) continue
+
+        const weight = set.actualWeight.value
+        const reps = set.actualReps
+
+        if (reps >= 3 && (threeRepMax === null || weight > threeRepMax)) {
+          threeRepMax = weight
+        }
+        if (reps >= 5 && (fiveRepMax === null || weight > fiveRepMax)) {
+          fiveRepMax = weight
+        }
+      }
+    }
+    return { threeRepMax, fiveRepMax }
+  }, [workoutHistory])
 
   const {
     register,
@@ -297,6 +322,33 @@ function ExerciseDetailPage() {
                 </span>
               </div>
               <OneRmChart data={oneRmHistory ?? []} />
+            </div>
+          )}
+
+          {/* Personal Records */}
+          {exercise.supports1RM && workoutHistory && workoutHistory.length > 0 && (
+            <div className="mt-6 space-y-3">
+              <span className="font-body text-xs font-medium uppercase tracking-widest text-warm-ash">
+                PERSONAL RECORDS
+              </span>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="flex flex-col gap-1">
+                  <span className="font-display text-2xl text-bone-white">
+                    {threeRepMax !== null ? `${threeRepMax} ${weightUnit}` : '--'}
+                  </span>
+                  <span className="font-body text-xs uppercase tracking-widest text-warm-ash">
+                    3RM
+                  </span>
+                </div>
+                <div className="flex flex-col gap-1">
+                  <span className="font-display text-2xl text-bone-white">
+                    {fiveRepMax !== null ? `${fiveRepMax} ${weightUnit}` : '--'}
+                  </span>
+                  <span className="font-body text-xs uppercase tracking-widest text-warm-ash">
+                    5RM
+                  </span>
+                </div>
+              </div>
             </div>
           )}
         </TabsContent>

--- a/src/routes/_authenticated/log.$workoutId.tsx
+++ b/src/routes/_authenticated/log.$workoutId.tsx
@@ -2,7 +2,9 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useActiveWorkout } from '@/hooks/use-active-workout'
 import { useExercises } from '@/hooks/use-exercises'
+import { useUserProfile } from '@/hooks/use-user-profile'
 import { useProgramFull } from '@/hooks/use-programs'
+import { detectPersonalRecords } from '@/lib/pr-detection'
 import { WorkoutHeader } from '@/components/workout/workout-header'
 import { ExerciseBlock, type SetRowData } from '@/components/workout/exercise-block'
 import { ProgramContextBanner } from '@/components/workout/program-context-banner'
@@ -23,7 +25,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { getExerciseModality, parseNumericInput, DEFAULT_CIRCUIT_REPS } from '@/lib/workout-utils'
-import type { Exercise, GroupType, SetType } from '@/domain/types'
+import type { Exercise, GroupType, PersonalRecord, SetType } from '@/domain/types'
 import type { LoggedActivityGroupWithActivities } from '@/stores/active-workout-store'
 
 export const Route = createFileRoute('/_authenticated/log/$workoutId')({
@@ -58,6 +60,7 @@ function ActiveWorkoutPage() {
   } = useActiveWorkout()
 
   const { data: allExercises = [] } = useExercises()
+  const { data: userProfile } = useUserProfile(workoutLog?.userId ?? '')
 
   // Resolve program/block names for the banner when in programmed mode
   const programId = workoutLog?.programContext?.programId
@@ -99,6 +102,8 @@ function ActiveWorkoutPage() {
   const [showDiscardDialog, setShowDiscardDialog] = useState(false)
   const [showSummary, setShowSummary] = useState(false)
   const [pageError, setPageError] = useState<string | null>(null)
+  // Detected personal records (computed at workout finish time)
+  const [detectedPrs, setDetectedPrs] = useState<PersonalRecord[]>([])
   // Store snapshot for summary display (captured at finish time)
   const [summaryData, setSummaryData] = useState<{
     workoutLog: typeof workoutLog
@@ -144,6 +149,24 @@ function ActiveWorkoutPage() {
       const result = await finishWorkout()
       setSummaryData(snapshot)
       setShowSummary(true)
+
+      // Detect personal records from the captured snapshot
+      if (userProfile) {
+        const allActivities = snapshot.loggedGroups.flatMap((g) => g.activities)
+        const allSets = allActivities.flatMap((a) => a.sets)
+        const prs = detectPersonalRecords(
+          {
+            log: snapshot.workoutLog,
+            groups: snapshot.loggedGroups,
+            activities: allActivities,
+            sets: allSets,
+          },
+          userProfile,
+          exerciseNames,
+        )
+        setDetectedPrs(prs)
+      }
+
       if (result?.advancementFailed) {
         setPageError(
           'Workout saved, but program position could not update. Check your connection.',
@@ -153,7 +176,7 @@ function ActiveWorkoutPage() {
       console.error('[workout-page] handleFinish:', err)
       setPageError('Failed to save workout. Please try again.')
     }
-  }, [workoutLog, loggedGroups, finishWorkout, programBannerProps])
+  }, [workoutLog, loggedGroups, finishWorkout, programBannerProps, userProfile, exerciseNames])
 
   const handleDiscard = useCallback(async () => {
     try {
@@ -227,6 +250,7 @@ function ActiveWorkoutPage() {
   const handleSummaryDone = useCallback(() => {
     setShowSummary(false)
     setSummaryData(null)
+    setDetectedPrs([])
     navigate({ to: '/' })
   }, [navigate])
 
@@ -243,6 +267,7 @@ function ActiveWorkoutPage() {
         onDone={handleSummaryDone}
         programName={summaryData.programName}
         blockName={summaryData.blockName}
+        personalRecords={detectedPrs}
       />
     )
   }

--- a/src/routes/_authenticated/vault.tsx
+++ b/src/routes/_authenticated/vault.tsx
@@ -1,4 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { VaultOverview } from '@/components/vault/vault-overview'
+import { VaultOneRmTab } from '@/components/vault/vault-one-rm-tab'
+import { VaultVolumeTab } from '@/components/vault/vault-volume-tab'
 
 export const Route = createFileRoute('/_authenticated/vault')({
   component: VaultPage,
@@ -6,9 +10,51 @@ export const Route = createFileRoute('/_authenticated/vault')({
 
 function VaultPage() {
   return (
-    <div className="p-4 text-bone-white font-body">
-      <h1 className="font-display text-industrial text-2xl mb-4">VAULT</h1>
-      <p className="text-warm-ash text-sm">Analytics and 1RM tracking</p>
+    <div className="min-h-[100dvh] bg-surface-anvil">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 pt-6 pb-4">
+        <span className="material-symbols-outlined text-2xl text-warm-ash">monitoring</span>
+        <h1 className="font-display text-industrial text-2xl text-bone-white">VAULT</h1>
+      </div>
+
+      {/* Tabs */}
+      <Tabs defaultValue="overview" className="px-4">
+        <TabsList
+          variant="line"
+          className="w-full justify-start border-b border-b-[rgba(91,64,57,0.15)]"
+        >
+          <TabsTrigger
+            value="overview"
+            className="min-h-12 font-body text-xs font-medium uppercase tracking-widest data-[state=active]:text-ember"
+          >
+            OVERVIEW
+          </TabsTrigger>
+          <TabsTrigger
+            value="one-rm"
+            className="min-h-12 font-body text-xs font-medium uppercase tracking-widest data-[state=active]:text-ember"
+          >
+            1RM TRENDS
+          </TabsTrigger>
+          <TabsTrigger
+            value="volume"
+            className="min-h-12 font-body text-xs font-medium uppercase tracking-widest data-[state=active]:text-ember"
+          >
+            VOLUME
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="overflow-y-auto pb-24">
+          <VaultOverview />
+        </TabsContent>
+
+        <TabsContent value="one-rm" className="overflow-y-auto pb-24">
+          <VaultOneRmTab />
+        </TabsContent>
+
+        <TabsContent value="volume" className="overflow-y-auto pb-24">
+          <VaultVolumeTab />
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/src/test/mocks/data-adapter.ts
+++ b/src/test/mocks/data-adapter.ts
@@ -61,6 +61,15 @@ export function createMockAdapter(
     setActiveProgram: vi.fn().mockResolvedValue({}),
     updateActiveProgram: vi.fn().mockResolvedValue({}),
     clearActiveProgram: vi.fn().mockResolvedValue(undefined),
+
+    // Analytics operations
+    getWeeklyVolume: vi.fn().mockResolvedValue([]),
+    getVaultSummary: vi.fn().mockResolvedValue({
+      totalWorkouts: 0,
+      totalVolumeLb: 0,
+      thisWeekWorkouts: 0,
+      thisWeekVolumeLb: 0,
+    }),
   }
 
   return { ...base, ...overrides }


### PR DESCRIPTION
## Summary

- **VAULT screen** -- full three-tab analytics screen replacing the placeholder stub: OVERVIEW (4 large metric cards), 1RM TRENDS (exercise picker + line chart), VOLUME (exercise picker + weekly horizontal load bars). Zero circular/radial charts. Zero border-radius. Iron & Ember palette throughout.
- **PR detection engine** -- `detectPersonalRecords()` pure function with 12 unit tests; detects 1RM, 3RM, 5RM, and max-rep bests; skips WARMUP/DROP sets; compares against stored profile maxes.
- **PR banner in workout summary** -- molten gradient banner (`#FFB59C → #FB5C1C`, `#511500` text) fires after workout completion when new bests are detected.
- **3RM/5RM records in exercise detail** -- RECORDS section below the 1RM chart, computed client-side via `useMemo` from existing `workoutHistory` data (no new API calls).
- **Analytics data layer** -- `getWeeklyVolume` and `getVaultSummary` added to `DataAdapter` interface, implemented in both `SupabaseAdapter` and `TauriAdapter` via client-side aggregation by ISO week.

## Test plan

- [ ] `bun run build` -- zero TypeScript errors
- [ ] `bun run lint` -- zero new violations
- [ ] `bun test src/lib/__tests__/pr-detection.test.ts` -- 12/12 pass
- [ ] Navigate to VAULT -- confirm three tabs render with no placeholder text
- [ ] OVERVIEW tab -- confirm four large metric cards with `text-readout` values
- [ ] 1RM TRENDS tab -- select an exercise, confirm line chart with arc (#86CFFF) data line
- [ ] VOLUME tab -- select an exercise, confirm horizontal VolumeLoadBar rows (no circular charts)
- [ ] Complete a workout with a new best -- confirm molten gradient PR banner appears in summary
- [ ] Navigate to exercise detail -- confirm RECORDS section shows 3RM and 5RM bests
- [ ] Verify all new vault components have 0px border-radius (no rounded corners)
- [ ] Verify no em dashes in any new user-visible strings