### PR TITLE
feat: complete sync pull path (Step 9)

### DIFF
--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -1,6 +1,6 @@
 use crate::error::AppError;
 use crate::sync::SyncEngine;
-use tauri::State;
+use tauri::{AppHandle, State};
 
 #[tauri::command]
 pub async fn sync_set_auth(
@@ -48,12 +48,43 @@ pub async fn sync_force_push(state: State<'_, SyncEngine>) -> Result<(), AppErro
 }
 
 #[tauri::command]
-pub async fn sync_force_pull(state: State<'_, SyncEngine>) -> Result<(), AppError> {
-    let current_state = state.current_state().await;
-    if let crate::sync::SyncState::Offline = current_state {
-        return Err(AppError::sync("Not authenticated for sync"));
+pub async fn sync_force_pull(
+    state: State<'_, SyncEngine>,
+    app_handle: AppHandle,
+) -> Result<(), AppError> {
+    let creds = state.credentials().await;
+    match creds {
+        Some(creds) => {
+            state
+                .transition_state(crate::sync::SyncState::Pulling)
+                .await;
+            match crate::sync::pull::pull_all(
+                state.pool(),
+                &creds.supabase_url,
+                &creds.supabase_key,
+                &creds.access_token,
+                &app_handle,
+            )
+            .await
+            {
+                Ok(()) => {
+                    state
+                        .transition_state(crate::sync::SyncState::Idle)
+                        .await;
+                    Ok(())
+                }
+                Err(e) => {
+                    state
+                        .transition_state(crate::sync::SyncState::Error {
+                            message: e.to_string(),
+                        })
+                        .await;
+                    Err(AppError::sync(&e.to_string()))
+                }
+            }
+        }
+        None => Err(AppError::sync("Not authenticated for sync")),
     }
-    Err(AppError::sync("Force pull is not yet implemented"))
 }
 
 #[tauri::command]

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -144,12 +144,34 @@ impl SyncEngine {
         let app_handle = self.app_handle.clone();
 
         tokio::spawn(async move {
+            let mut first_run = true;
+
             loop {
                 let creds = credentials.read().await.clone();
                 let creds = match creds {
                     Some(c) => c,
                     None => break,
                 };
+
+                // Initial pull on first sign-in
+                if first_run {
+                    first_run = false;
+                    if needs_initial_pull(&pool).await {
+                        transition_state(&state, &app_handle, SyncState::Pulling).await;
+                        if let Err(e) = pull::pull_all(
+                            &pool,
+                            &creds.supabase_url,
+                            &creds.supabase_key,
+                            &creds.access_token,
+                            &app_handle,
+                        )
+                        .await
+                        {
+                            log::error!("[sync] Initial pull failed: {e}");
+                            // Continue with push -- don't abort the loop
+                        }
+                    }
+                }
 
                 // Push phase
                 transition_state(&state, &app_handle, SyncState::Pushing).await;
@@ -201,5 +223,69 @@ impl SyncEngine {
                 tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
             }
         })
+    }
+}
+
+/// Check whether this device has ever completed a pull.
+///
+/// Returns `true` when all `last_pull_at` values are 0 (or the table is empty),
+/// meaning the device has never pulled remote data.
+async fn needs_initial_pull(pool: &SqlitePool) -> bool {
+    let result: Option<(i64,)> =
+        sqlx::query_as("SELECT MAX(last_pull_at) FROM sync_metadata")
+            .fetch_optional(pool)
+            .await
+            .unwrap_or(None);
+
+    match result {
+        Some((max_pull,)) => max_pull == 0,
+        None => true, // Empty table means we never pulled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::SqlitePool;
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS sync_metadata (
+                table_name TEXT PRIMARY KEY,
+                last_push_at INTEGER NOT NULL DEFAULT 0,
+                last_pull_at INTEGER NOT NULL DEFAULT 0
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn needs_initial_pull_empty_table() {
+        let pool = test_pool().await;
+        assert!(needs_initial_pull(&pool).await);
+    }
+
+    #[tokio::test]
+    async fn needs_initial_pull_all_zero() {
+        let pool = test_pool().await;
+        sqlx::query("INSERT INTO sync_metadata (table_name, last_pull_at) VALUES ('exercises', 0), ('workout_logs', 0)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(needs_initial_pull(&pool).await);
+    }
+
+    #[tokio::test]
+    async fn needs_initial_pull_one_nonzero() {
+        let pool = test_pool().await;
+        sqlx::query("INSERT INTO sync_metadata (table_name, last_pull_at) VALUES ('exercises', 0), ('workout_logs', 1700000000)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(!needs_initial_pull(&pool).await);
     }
 }

--- a/src-tauri/src/sync/pull.rs
+++ b/src-tauri/src/sync/pull.rs
@@ -1,9 +1,194 @@
 use futures_util::{SinkExt, StreamExt};
+use reqwest::Client;
 use serde_json::{json, Value};
 use sqlx::SqlitePool;
 use tauri::{AppHandle, Emitter};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use url::Url;
+
+/// Parse a remote timestamp value into epoch seconds.
+///
+/// Handles multiple formats from Supabase:
+/// - Already numeric (i64) -- returned as-is
+/// - ISO 8601 string with timezone (e.g. "2026-03-27T14:30:00+00:00")
+/// - ISO 8601 string without timezone (e.g. "2026-03-27T14:30:00.000")
+/// - Falls back to 0 (safe default: local wins on conflict)
+fn parse_remote_timestamp(val: Option<&Value>) -> i64 {
+    let val = match val {
+        Some(v) => v,
+        None => return 0,
+    };
+
+    // Try numeric first (e.g. from REST API)
+    if let Some(n) = val.as_i64() {
+        return n;
+    }
+
+    // Try string-based ISO 8601 parsing
+    if let Some(s) = val.as_str() {
+        // RFC 3339 / ISO 8601 with timezone offset
+        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+            return dt.timestamp();
+        }
+        // Supabase format without timezone (assume UTC)
+        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f") {
+            return dt.and_utc().timestamp();
+        }
+        // Try without fractional seconds
+        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+            return dt.and_utc().timestamp();
+        }
+    }
+
+    0
+}
+
+/// Coerce a JSON value from Supabase into the type expected by SQLite.
+///
+/// SQLite stores timestamps as INTEGER (epoch seconds), booleans as INTEGER
+/// (0/1), and JSON blobs as TEXT. This function performs the necessary
+/// conversion based on the declared column type from `pragma_table_info`.
+fn coerce_value(sqlite_type: &str, json_val: &Value) -> Value {
+    match sqlite_type.to_uppercase().as_str() {
+        "INTEGER" => match json_val {
+            Value::Bool(b) => json!(if *b { 1 } else { 0 }),
+            Value::String(s) => {
+                // Try ISO 8601 -> epoch seconds
+                if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+                    json!(dt.timestamp())
+                } else if let Ok(dt) =
+                    chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
+                {
+                    json!(dt.and_utc().timestamp())
+                } else if let Ok(dt) =
+                    chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
+                {
+                    json!(dt.and_utc().timestamp())
+                } else {
+                    // Not a timestamp string -- pass through (may be a
+                    // numeric string like "42")
+                    if let Ok(n) = s.parse::<i64>() {
+                        json!(n)
+                    } else {
+                        json_val.clone()
+                    }
+                }
+            }
+            Value::Number(_) | Value::Null => json_val.clone(),
+            // Objects/arrays should not be INTEGER, pass through
+            _ => json_val.clone(),
+        },
+        "TEXT" => match json_val {
+            Value::Object(_) | Value::Array(_) => {
+                // Serialize nested JSON to a string for SQLite TEXT storage
+                json!(json_val.to_string())
+            }
+            Value::String(_) | Value::Null => json_val.clone(),
+            // Booleans/numbers as text -- convert to string representation
+            Value::Bool(b) => json!(b.to_string()),
+            Value::Number(n) => json!(n.to_string()),
+        },
+        "REAL" => json_val.clone(),
+        _ => json_val.clone(),
+    }
+}
+
+const PAGE_SIZE: usize = 1000;
+
+/// Pull all rows from a single Supabase table into local SQLite.
+///
+/// Paginates via the `Range` header in chunks of 1000 rows, upserting each
+/// row locally. Updates `sync_metadata.last_pull_at` on completion.
+pub async fn pull_table(
+    pool: &SqlitePool,
+    client: &Client,
+    table: &str,
+    supabase_url: &str,
+    supabase_key: &str,
+    access_token: &str,
+    app_handle: &AppHandle,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let _ = app_handle.emit(
+        "sync:pull_progress",
+        json!({"table": table, "status": "pulling"}),
+    );
+
+    let mut offset: usize = 0;
+    loop {
+        let url = format!(
+            "{}/rest/v1/{}?select=*&order=id",
+            supabase_url, table
+        );
+
+        let range_end = offset + PAGE_SIZE - 1;
+        let response = client
+            .get(&url)
+            .header("apikey", supabase_key)
+            .header("Authorization", format!("Bearer {}", access_token))
+            .header("Range", format!("{}-{}", offset, range_end))
+            .header("Prefer", "count=exact")
+            .send()
+            .await?;
+
+        let rows: Vec<Value> = response.json().await?;
+        let row_count = rows.len();
+
+        for row in &rows {
+            upsert_row(pool, table, row).await?;
+        }
+
+        if row_count < PAGE_SIZE {
+            break;
+        }
+        offset += PAGE_SIZE;
+    }
+
+    // Update sync_metadata with the pull timestamp (epoch seconds)
+    let now = chrono::Utc::now().timestamp();
+    sqlx::query(
+        "INSERT INTO sync_metadata (table_name, last_pull_at, last_push_at) VALUES (?, ?, 0)
+         ON CONFLICT(table_name) DO UPDATE SET last_pull_at = ?",
+    )
+    .bind(table)
+    .bind(now)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    let _ = app_handle.emit(
+        "sync:pull_progress",
+        json!({"table": table, "status": "done"}),
+    );
+
+    Ok(())
+}
+
+/// Pull all syncable tables from Supabase into local SQLite.
+///
+/// Iterates over `SYNCABLE_TABLES`, pulling each one sequentially. Emits a
+/// `sync:data_changed` event after each table succeeds so the frontend can
+/// progressively invalidate caches. Fails fast on any error.
+pub async fn pull_all(
+    pool: &SqlitePool,
+    supabase_url: &str,
+    supabase_key: &str,
+    access_token: &str,
+    app_handle: &AppHandle,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let client = Client::new();
+
+    for table in super::SYNCABLE_TABLES {
+        pull_table(pool, &client, table, supabase_url, supabase_key, access_token, app_handle)
+            .await?;
+
+        let _ = app_handle.emit(
+            "sync:data_changed",
+            json!({"table": table}),
+        );
+    }
+
+    Ok(())
+}
 
 pub async fn start_realtime_subscription(
     pool: SqlitePool,
@@ -170,10 +355,7 @@ async fn upsert_row(pool: &SqlitePool, table: &str, record: &Value) -> Result<()
             .fetch_optional(pool)
             .await?;
 
-    let remote_updated_at = record
-        .get("updated_at")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
+    let remote_updated_at = parse_remote_timestamp(record.get("updated_at"));
 
     if let Some((local_ts,)) = local_updated_at {
         if resolve_conflict(local_ts, remote_updated_at) == Winner::Local {
@@ -182,11 +364,74 @@ async fn upsert_row(pool: &SqlitePool, table: &str, record: &Value) -> Result<()
         }
     }
 
-    // STUB: The actual SQLite upsert is not yet implemented.
-    // Conflict resolution above is wired and tested, but the winning remote
-    // record is not written to SQLite. Production implementation requires
-    // per-table column mapping to build a dynamic INSERT ... ON CONFLICT.
-    log::warn!("[pull] upsert_row: remote record for {table}/{row_id} acknowledged but NOT written (stub)");
+    // Discover table columns and their declared types via pragma
+    let columns: Vec<(String, String)> =
+        sqlx::query_as("SELECT name, type FROM pragma_table_info(?)")
+            .bind(table)
+            .fetch_all(pool)
+            .await?;
+
+    if columns.is_empty() {
+        log::warn!("[pull] upsert_row: table {table} has no columns (missing table?)");
+        return Ok(());
+    }
+
+    // Filter to columns present in the remote JSON record
+    let matched: Vec<(&str, &str, Value)> = columns
+        .iter()
+        .filter_map(|(col_name, col_type)| {
+            record.get(col_name.as_str()).map(|json_val| {
+                let coerced = coerce_value(col_type, json_val);
+                (col_name.as_str(), col_type.as_str(), coerced)
+            })
+        })
+        .collect();
+
+    if matched.is_empty() {
+        log::warn!("[pull] upsert_row: no matching columns for {table}/{row_id}");
+        return Ok(());
+    }
+
+    // Build dynamic INSERT ... ON CONFLICT(id) DO UPDATE SET ...
+    let col_names: Vec<&str> = matched.iter().map(|(name, _, _)| *name).collect();
+    let placeholders: Vec<String> = (1..=col_names.len()).map(|i| format!("?{i}")).collect();
+    let update_set: Vec<String> = col_names
+        .iter()
+        .filter(|name| **name != "id")
+        .map(|name| format!("{name}=excluded.{name}"))
+        .collect();
+
+    let sql = format!(
+        "INSERT INTO {table} ({cols}) VALUES ({vals}) ON CONFLICT(id) DO UPDATE SET {sets}",
+        cols = col_names.join(", "),
+        vals = placeholders.join(", "),
+        sets = update_set.join(", "),
+    );
+
+    // Bind each coerced value
+    let mut query = sqlx::query(&sql);
+    for (_, _, ref coerced) in &matched {
+        query = match coerced {
+            Value::Null => query.bind(None::<String>),
+            Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    query.bind(i)
+                } else if let Some(f) = n.as_f64() {
+                    query.bind(f)
+                } else {
+                    query.bind(n.to_string())
+                }
+            }
+            Value::String(s) => query.bind(s.clone()),
+            Value::Bool(b) => query.bind(if *b { 1i64 } else { 0i64 }),
+            // Objects/arrays should already be serialized by coerce_value,
+            // but handle gracefully just in case
+            _ => query.bind(coerced.to_string()),
+        };
+    }
+
+    query.execute(pool).await?;
+    log::info!("[pull] upsert_row: wrote remote record for {table}/{row_id}");
     Ok(())
 }
 
@@ -196,4 +441,361 @@ async fn delete_row(pool: &SqlitePool, table: &str, row_id: &str) -> Result<(), 
         .execute(pool)
         .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use sqlx::Row;
+
+    // ================================================================
+    // S001-T: parse_remote_timestamp tests
+    // ================================================================
+
+    #[test]
+    fn parse_timestamp_iso8601_with_timezone() {
+        let val = json!("2026-03-27T14:30:00+00:00");
+        let ts = parse_remote_timestamp(Some(&val));
+        // 2026-03-27T14:30:00Z in epoch seconds
+        let expected = chrono::DateTime::parse_from_rfc3339("2026-03-27T14:30:00+00:00")
+            .unwrap()
+            .timestamp();
+        assert_eq!(ts, expected);
+        assert_eq!(ts, 1774621800); // verify exact value
+    }
+
+    #[test]
+    fn parse_timestamp_i64_value() {
+        let val = json!(1774621800_i64);
+        let ts = parse_remote_timestamp(Some(&val));
+        assert_eq!(ts, 1774621800);
+    }
+
+    #[test]
+    fn parse_timestamp_null() {
+        let val = json!(null);
+        let ts = parse_remote_timestamp(Some(&val));
+        assert_eq!(ts, 0);
+    }
+
+    #[test]
+    fn parse_timestamp_none() {
+        let ts = parse_remote_timestamp(None);
+        assert_eq!(ts, 0);
+    }
+
+    #[test]
+    fn parse_timestamp_garbage_string() {
+        let val = json!("not-a-timestamp");
+        let ts = parse_remote_timestamp(Some(&val));
+        assert_eq!(ts, 0);
+    }
+
+    #[test]
+    fn parse_timestamp_iso_without_timezone() {
+        let val = json!("2026-03-27T14:30:00.000");
+        let ts = parse_remote_timestamp(Some(&val));
+        let expected =
+            chrono::NaiveDateTime::parse_from_str("2026-03-27T14:30:00.000", "%Y-%m-%dT%H:%M:%S%.f")
+                .unwrap()
+                .and_utc()
+                .timestamp();
+        assert_eq!(ts, expected);
+    }
+
+    #[test]
+    fn parse_timestamp_iso_without_fractional() {
+        let val = json!("2026-03-27T14:30:00");
+        let ts = parse_remote_timestamp(Some(&val));
+        assert!(ts > 0);
+    }
+
+    // ================================================================
+    // S001-T: coerce_value tests
+    // ================================================================
+
+    #[test]
+    fn coerce_bool_true_to_integer() {
+        assert_eq!(coerce_value("INTEGER", &json!(true)), json!(1));
+    }
+
+    #[test]
+    fn coerce_bool_false_to_integer() {
+        assert_eq!(coerce_value("INTEGER", &json!(false)), json!(0));
+    }
+
+    #[test]
+    fn coerce_iso_string_to_integer_epoch() {
+        let result = coerce_value("INTEGER", &json!("2026-03-27T14:30:00+00:00"));
+        let expected = chrono::DateTime::parse_from_rfc3339("2026-03-27T14:30:00+00:00")
+            .unwrap()
+            .timestamp();
+        assert_eq!(result, json!(expected));
+    }
+
+    #[test]
+    fn coerce_json_object_to_text() {
+        let obj = json!({"a": 1});
+        let result = coerce_value("TEXT", &obj);
+        // Should be a JSON string containing the serialized object
+        assert_eq!(result, json!("{\"a\":1}"));
+    }
+
+    #[test]
+    fn coerce_json_array_to_text() {
+        let arr = json!([1, 2, 3]);
+        let result = coerce_value("TEXT", &arr);
+        assert_eq!(result, json!("[1,2,3]"));
+    }
+
+    #[test]
+    fn coerce_string_to_text_passthrough() {
+        assert_eq!(coerce_value("TEXT", &json!("hello")), json!("hello"));
+    }
+
+    #[test]
+    fn coerce_null_integer_passthrough() {
+        assert_eq!(coerce_value("INTEGER", &json!(null)), json!(null));
+    }
+
+    #[test]
+    fn coerce_null_text_passthrough() {
+        assert_eq!(coerce_value("TEXT", &json!(null)), json!(null));
+    }
+
+    #[test]
+    fn coerce_number_integer_passthrough() {
+        assert_eq!(coerce_value("INTEGER", &json!(42)), json!(42));
+    }
+
+    #[test]
+    fn coerce_real_passthrough() {
+        assert_eq!(coerce_value("REAL", &json!(3.14)), json!(3.14));
+    }
+
+    #[test]
+    fn coerce_numeric_string_to_integer() {
+        assert_eq!(coerce_value("INTEGER", &json!("42")), json!(42));
+    }
+
+    #[test]
+    fn coerce_bool_to_text() {
+        assert_eq!(coerce_value("TEXT", &json!(true)), json!("true"));
+    }
+
+    // ================================================================
+    // S002-T: upsert_row integration tests (in-memory SQLite)
+    // ================================================================
+
+    async fn setup_test_db() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .connect(":memory:")
+            .await
+            .expect("connect in-memory db");
+
+        sqlx::query(
+            "CREATE TABLE test_table (
+                id TEXT PRIMARY KEY,
+                name TEXT,
+                is_custom INTEGER,
+                updated_at INTEGER,
+                aliases TEXT
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create test_table");
+
+        pool
+    }
+
+    #[tokio::test]
+    async fn upsert_inserts_new_row() {
+        let pool = setup_test_db().await;
+
+        let record = json!({
+            "id": "row-1",
+            "name": "Bench Press",
+            "is_custom": false,
+            "updated_at": "2026-03-27T14:30:00+00:00",
+            "aliases": ["bench", "bp"]
+        });
+
+        upsert_row(&pool, "test_table", &record).await.unwrap();
+
+        let row = sqlx::query("SELECT id, name, is_custom, updated_at, aliases FROM test_table WHERE id = ?")
+            .bind("row-1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let id: String = row.get("id");
+        let name: String = row.get("name");
+        let is_custom: i64 = row.get("is_custom");
+        let updated_at: i64 = row.get("updated_at");
+        let aliases: String = row.get("aliases");
+
+        assert_eq!(id, "row-1");
+        assert_eq!(name, "Bench Press");
+        assert_eq!(is_custom, 0); // false -> 0
+        let expected_ts = chrono::DateTime::parse_from_rfc3339("2026-03-27T14:30:00+00:00")
+            .unwrap()
+            .timestamp();
+        assert_eq!(updated_at, expected_ts);
+        assert_eq!(aliases, "[\"bench\",\"bp\"]"); // array -> serialized text
+    }
+
+    #[tokio::test]
+    async fn upsert_updates_when_remote_newer() {
+        let pool = setup_test_db().await;
+
+        // Seed a local row with old timestamp
+        sqlx::query(
+            "INSERT INTO test_table (id, name, is_custom, updated_at, aliases)
+             VALUES ('row-2', 'Old Name', 0, 100, NULL)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Remote record with a newer timestamp
+        let record = json!({
+            "id": "row-2",
+            "name": "Updated Name",
+            "is_custom": true,
+            "updated_at": "2026-03-27T14:30:00+00:00",
+            "aliases": null
+        });
+
+        upsert_row(&pool, "test_table", &record).await.unwrap();
+
+        let row = sqlx::query("SELECT name, is_custom, updated_at FROM test_table WHERE id = ?")
+            .bind("row-2")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let name: String = row.get("name");
+        let is_custom: i64 = row.get("is_custom");
+        let updated_at: i64 = row.get("updated_at");
+
+        assert_eq!(name, "Updated Name");
+        assert_eq!(is_custom, 1); // true -> 1
+        assert!(updated_at > 100);
+    }
+
+    #[tokio::test]
+    async fn upsert_skips_when_local_newer() {
+        let pool = setup_test_db().await;
+
+        // Seed a local row with a very large timestamp (far future)
+        sqlx::query(
+            "INSERT INTO test_table (id, name, is_custom, updated_at, aliases)
+             VALUES ('row-3', 'Local Name', 1, 9999999999, NULL)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Remote record with an older timestamp
+        let record = json!({
+            "id": "row-3",
+            "name": "Remote Name",
+            "is_custom": false,
+            "updated_at": "2026-03-27T14:30:00+00:00",
+            "aliases": null
+        });
+
+        upsert_row(&pool, "test_table", &record).await.unwrap();
+
+        // Verify local data is unchanged
+        let row = sqlx::query("SELECT name, is_custom FROM test_table WHERE id = ?")
+            .bind("row-3")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let name: String = row.get("name");
+        let is_custom: i64 = row.get("is_custom");
+
+        assert_eq!(name, "Local Name");
+        assert_eq!(is_custom, 1);
+    }
+
+    #[tokio::test]
+    async fn upsert_handles_null_optional_columns() {
+        let pool = setup_test_db().await;
+
+        let record = json!({
+            "id": "row-4",
+            "name": "Squat",
+            "is_custom": null,
+            "updated_at": 500,
+            "aliases": null
+        });
+
+        upsert_row(&pool, "test_table", &record).await.unwrap();
+
+        let row = sqlx::query("SELECT id, name, is_custom, aliases FROM test_table WHERE id = ?")
+            .bind("row-4")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let name: String = row.get("name");
+        let is_custom: Option<i64> = row.get("is_custom");
+        let aliases: Option<String> = row.get("aliases");
+
+        assert_eq!(name, "Squat");
+        assert!(is_custom.is_none());
+        assert!(aliases.is_none());
+    }
+
+    #[tokio::test]
+    async fn upsert_ignores_extra_json_fields() {
+        let pool = setup_test_db().await;
+
+        // Record has fields not in the table schema
+        let record = json!({
+            "id": "row-5",
+            "name": "Deadlift",
+            "is_custom": false,
+            "updated_at": 1000,
+            "aliases": null,
+            "nonexistent_column": "should be ignored"
+        });
+
+        upsert_row(&pool, "test_table", &record).await.unwrap();
+
+        let row = sqlx::query("SELECT name FROM test_table WHERE id = ?")
+            .bind("row-5")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        let name: String = row.get("name");
+        assert_eq!(name, "Deadlift");
+    }
+
+    #[tokio::test]
+    async fn upsert_empty_id_is_noop() {
+        let pool = setup_test_db().await;
+
+        let record = json!({
+            "id": "",
+            "name": "Ghost",
+            "updated_at": 1000
+        });
+
+        upsert_row(&pool, "test_table", &record).await.unwrap();
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM test_table")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(count.0, 0);
+    }
 }


### PR DESCRIPTION
## Summary

- **Fix broken pull upsert**: `upsert_row` in `pull.rs` was stubbed -- remote changes detected via Supabase Realtime were acknowledged but never written to local SQLite. Also fixed a timestamp parsing bug where ISO 8601 strings were always parsed as 0, silently discarding all remote updates.
- **Implement force-pull**: `sync_force_pull` command now downloads all rows from all 15 syncable tables via paginated Supabase REST API requests and upserts them locally with proper state transitions (`Pulling` -> `Idle`/`Error`).
- **Add auto-pull on first sign-in**: Sync loop detects when `last_pull_at` is 0 for all tables and runs a full pull before the first push cycle, so new devices get populated immediately.

### Key technical decisions

- Dynamic column discovery via `pragma_table_info` (mirrors push path pattern) -- no hardcoded column lists
- Type coercion layer converts Supabase types to SQLite: ISO 8601 -> epoch seconds, JSON booleans -> 0/1, JSONB -> serialized TEXT
- `INSERT ... ON CONFLICT(id) DO UPDATE SET` for atomic upsert
- Pagination via `Range` header (1000 rows per page)
- Initial pull failure logs error but does not abort the sync loop

### Files changed

| File | Changes |
|------|---------|
| `src-tauri/src/sync/pull.rs` | `parse_remote_timestamp`, `coerce_value`, dynamic `upsert_row`, `pull_table`, `pull_all` + 25 tests |
| `src-tauri/src/sync/mod.rs` | `needs_initial_pull`, modified sync loop + 3 tests |
| `src-tauri/src/commands/sync.rs` | Replaced `sync_force_pull` stub |

## Test plan

- [x] 49 Rust tests pass (`cargo test` in `src-tauri/`)
- [x] `cargo clippy -- -D warnings` clean (no new warnings)
- [ ] Manual: sign in on Tauri app, verify existing Supabase data appears locally
- [ ] Manual: log workout on web, verify it appears on Tauri app via Realtime
- [ ] Manual: trigger force-pull from sync indicator, verify full download
- [ ] Manual: sign in on fresh device, verify auto-pull populates all data