### PR TITLE
feat: add link preview metadata with OG tags, Twitter Cards, and useMetadata hook

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,35 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/logos/print_transparent.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ardent Forge</title>
+    <meta name="description" content="Track workouts, build programs, and forge your fitness path with Ardent Forge." />
+    <meta name="theme-color" content="#863bff" />
+
+    <!-- Favicons -->
+    <link rel="icon" type="image/svg+xml" href="/logos/print_transparent.svg" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/logos/icononly_transparent.png" />
+    <link rel="apple-touch-icon" href="/logos/icononly.png" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Ardent Forge" />
+    <meta property="og:description" content="Track workouts, build programs, and forge your fitness path with Ardent Forge." />
+    <meta property="og:image" content="/logos/fulllogo.png" />
+    <meta property="og:image:alt" content="Ardent Forge logo" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:site_name" content="Ardent Forge" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Ardent Forge" />
+    <meta name="twitter:description" content="Track workouts, build programs, and forge your fitness path with Ardent Forge." />
+    <meta name="twitter:image" content="/logos/fulllogo.png" />
+    <meta name="twitter:image:alt" content="Ardent Forge logo" />
+
+    <!-- Web App Manifest -->
+    <link rel="manifest" href="/manifest.webmanifest" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,21 @@
+{
+  "name": "Ardent Forge",
+  "short_name": "Ardent Forge",
+  "description": "Track workouts, build programs, and forge your fitness path.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#1a1a1a",
+  "theme_color": "#863bff",
+  "icons": [
+    {
+      "src": "/logos/icononly_transparent.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/logos/icononly.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/hooks/use-metadata.ts
+++ b/src/hooks/use-metadata.ts
@@ -1,0 +1,58 @@
+import { useEffect } from 'react'
+
+interface MetadataOptions {
+  title?: string
+  description?: string
+  ogImage?: string
+}
+
+const DEFAULT_TITLE = 'Ardent Forge'
+const DEFAULT_DESCRIPTION =
+  'Track workouts, build programs, and forge your fitness path with Ardent Forge.'
+const DEFAULT_OG_IMAGE = '/logos/fulllogo.png'
+
+function setMetaTag(property: string, content: string, attribute: 'property' | 'name' = 'property') {
+  const selector = `meta[${attribute}="${property}"]`
+  let element = document.querySelector<HTMLMetaElement>(selector)
+  if (element) {
+    element.content = content
+  } else {
+    element = document.createElement('meta')
+    element.setAttribute(attribute, property)
+    element.content = content
+    document.head.appendChild(element)
+  }
+}
+
+/**
+ * Sets the document title and updates Open Graph / Twitter Card meta tags.
+ * Resets to defaults on unmount so stale metadata is never left behind.
+ */
+export function useMetadata({ title, description, ogImage }: MetadataOptions = {}) {
+  useEffect(() => {
+    const fullTitle = title ? `${title} | Ardent Forge` : DEFAULT_TITLE
+    const desc = description ?? DEFAULT_DESCRIPTION
+    const image = ogImage ?? DEFAULT_OG_IMAGE
+
+    document.title = fullTitle
+
+    setMetaTag('description', desc, 'name')
+    setMetaTag('og:title', fullTitle)
+    setMetaTag('og:description', desc)
+    setMetaTag('og:image', image)
+    setMetaTag('twitter:title', fullTitle)
+    setMetaTag('twitter:description', desc)
+    setMetaTag('twitter:image', image)
+
+    return () => {
+      document.title = DEFAULT_TITLE
+      setMetaTag('description', DEFAULT_DESCRIPTION, 'name')
+      setMetaTag('og:title', DEFAULT_TITLE)
+      setMetaTag('og:description', DEFAULT_DESCRIPTION)
+      setMetaTag('og:image', DEFAULT_OG_IMAGE)
+      setMetaTag('twitter:title', DEFAULT_TITLE)
+      setMetaTag('twitter:description', DEFAULT_DESCRIPTION)
+      setMetaTag('twitter:image', DEFAULT_OG_IMAGE)
+    }
+  }, [title, description, ogImage])
+}

--- a/src/routes/s/$token.tsx
+++ b/src/routes/s/$token.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useResolveShareLink, useSharedProgram, useSharedWorkout } from '@/hooks/use-share-links'
+import { useMetadata } from '@/hooks/use-metadata'
 import { SharedProgramView } from '@/components/sharing/shared-program-view'
 import { SharedWorkoutView } from '@/components/sharing/shared-workout-view'
 import { CloneProgramButton } from '@/components/sharing/clone-program-button'
@@ -124,6 +125,19 @@ function SharedTokenPage() {
   const { data: workoutData, isLoading: isWorkoutLoading, isError: isWorkoutError } = useSharedWorkout(
     isWorkoutLink ? token : '',
   )
+
+  // Dynamic link preview metadata
+  const metadataTitle = isProgramLink && programData
+    ? programData.name
+    : isWorkoutLink && workoutData
+      ? 'Shared Workout'
+      : 'Shared Link'
+  const metadataDescription = isProgramLink && programData
+    ? `Check out "${programData.name}" on Ardent Forge`
+    : isWorkoutLink && workoutData
+      ? 'View this workout shared via Ardent Forge'
+      : 'View content shared via Ardent Forge'
+  useMetadata({ title: metadataTitle, description: metadataDescription })
 
   // Loading state
   if (isResolvingLink) {


### PR DESCRIPTION
Add comprehensive link preview support so shared URLs display rich previews
on social platforms and messaging apps. Includes a useMetadata hook for
dynamic per-route title and description updates, used on share pages.