### PR TITLE
fix(auth): prevent PKCE code race condition on OAuth callback

### DIFF
--- a/src/lib/__tests__/supabase.test.ts
+++ b/src/lib/__tests__/supabase.test.ts
@@ -44,7 +44,9 @@ describe('supabase client lifecycle', () => {
 
     expect(client).toBeDefined()
     expect(client).toBe(getSupabaseClient())
-    expect(mockCreateClient).toHaveBeenCalledWith('https://example.supabase.co', 'test-anon-key')
+    expect(mockCreateClient).toHaveBeenCalledWith('https://example.supabase.co', 'test-anon-key', {
+      auth: { detectSessionInUrl: false },
+    })
   })
 
   // -------------------------------------------------------------------------

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -25,7 +25,11 @@ export function initSupabaseFromConfig(config: BackendConfig): SupabaseClient {
       `[supabase] Invalid Supabase URL: "${config.supabaseUrl}". Provide a valid HTTPS URL.`,
     )
   }
-  _client = createClient(config.supabaseUrl, config.supabaseKey)
+  _client = createClient(config.supabaseUrl, config.supabaseKey, {
+    auth: {
+      detectSessionInUrl: false,
+    },
+  })
   return _client
 }
 


### PR DESCRIPTION
## Summary
- Disable `detectSessionInUrl` on the Supabase client to prevent `_initialize()` from auto-exchanging the PKCE auth code before the `/auth/callback` route handler can
- The dedicated callback route already handles code exchange manually; the double-exchange caused the second attempt to fail (code already consumed), redirecting to `/sign-in?reason=oauth_error`

## Test plan
- [x] Existing supabase client tests pass (updated assertion for new `createClient` options)
- [x] Auth OAuth and callback tests pass (12/12)
- [ ] Verify Google sign-in works on `https://app.ardentforge.app` after deploy