### PR TITLE
fix(auth): enable PKCE flow for OAuth sign-in

### DIFF
--- a/src/lib/__tests__/supabase.test.ts
+++ b/src/lib/__tests__/supabase.test.ts
@@ -45,7 +45,7 @@ describe('supabase client lifecycle', () => {
     expect(client).toBeDefined()
     expect(client).toBe(getSupabaseClient())
     expect(mockCreateClient).toHaveBeenCalledWith('https://example.supabase.co', 'test-anon-key', {
-      auth: { detectSessionInUrl: false },
+      auth: { flowType: 'pkce', detectSessionInUrl: false },
     })
   })
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -27,6 +27,7 @@ export function initSupabaseFromConfig(config: BackendConfig): SupabaseClient {
   }
   _client = createClient(config.supabaseUrl, config.supabaseKey, {
     auth: {
+      flowType: 'pkce',
       detectSessionInUrl: false,
     },
   })


### PR DESCRIPTION
## Summary
- Add `flowType: 'pkce'` to the Supabase client auth options
- Without this, the client defaults to implicit flow, returning tokens as hash fragments (`#access_token=...`) that the `/auth/callback` route cannot parse (it expects `?code=` query params from PKCE)
- Follows up on #54 which added `detectSessionInUrl: false` but missed this option in the squash merge

## Test plan
- [x] All 18 auth-related tests pass
- [ ] Verify Google sign-in works on production after deploy