### PR TITLE
fix(connect): add CORS headers to discovery API

### DIFF
--- a/api/discovery.ts
+++ b/api/discovery.ts
@@ -1,6 +1,14 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 
-export default function handler(_req: VercelRequest, res: VercelResponse) {
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end()
+    return
+  }
+
   const supabaseUrl = process.env.VITE_SUPABASE_URL
   const supabaseKey = process.env.VITE_SUPABASE_PUB_KEY
 


### PR DESCRIPTION
## Summary

- Add `Access-Control-Allow-Origin: *` to the discovery API function
- Tauri WebView runs from `https://tauri.localhost`, making the fetch cross-origin
- Without CORS headers the WebView blocks the response

## Test plan

- [x] `curl -sI` confirms CORS header present
- [ ] CI passes