### PR TITLE
feat: add ability to duplicate session templates from library

### DIFF
--- a/src/components/session-builder/session-template-card.tsx
+++ b/src/components/session-builder/session-template-card.tsx
@@ -22,6 +22,8 @@ interface SessionTemplateCardProps {
   exerciseCount?: number
   onEdit: () => void
   onDelete: () => void
+  onClone?: () => void
+  isCloning?: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -48,6 +50,8 @@ export function SessionTemplateCard({
   exerciseCount,
   onEdit,
   onDelete,
+  onClone,
+  isCloning,
 }: SessionTemplateCardProps) {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const scoringLabel = SCORING_LABELS[template.scoring]
@@ -84,6 +88,28 @@ export function SessionTemplateCard({
             </span>
           )}
         </button>
+
+        {/* Clone button */}
+        {onClone && (
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={(e) => {
+              e.stopPropagation()
+              if (!isCloning) onClone()
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.stopPropagation()
+                if (!isCloning) onClone()
+              }
+            }}
+            className={`flex min-h-10 min-w-10 items-center justify-center text-warm-ash/60 hover:text-ember ${isCloning ? 'animate-pulse opacity-50' : ''}`}
+            aria-label={`Duplicate ${template.name}`}
+          >
+            <Icon name="content_copy" size={18} />
+          </div>
+        )}
 
         {/* Delete button */}
         <button

--- a/src/hooks/__tests__/use-session-templates.test.ts
+++ b/src/hooks/__tests__/use-session-templates.test.ts
@@ -25,6 +25,7 @@ import {
   useCreateSessionTemplate,
   useUpdateSessionTemplate,
   useDeleteSessionTemplate,
+  useCloneSessionTemplate,
 } from '../use-session-templates'
 
 beforeEach(() => {
@@ -209,5 +210,26 @@ describe('useDeleteSessionTemplate', () => {
     await result.current.mutateAsync('st-1')
 
     expect(mockAdapter.deleteSessionTemplate).toHaveBeenCalledWith('st-1')
+  })
+})
+
+describe('useCloneSessionTemplate', () => {
+  it('calls adapter.cloneSessionTemplate and invalidates queries', async () => {
+    const group = buildActivityGroup()
+    const { activities: _, ...groupFlat } = group
+    const activity = buildActivity()
+    const full = {
+      template: buildSessionTemplate({ id: 'st-cloned', name: 'Original (Copy)' }),
+      groups: [groupFlat],
+      activities: [activity],
+      eventItems: [],
+    }
+    vi.mocked(mockAdapter.cloneSessionTemplate).mockResolvedValue(full)
+
+    const { result } = renderHook(() => useCloneSessionTemplate(), { wrapper: TestWrapper })
+
+    await result.current.mutateAsync({ id: 'st-1', userId: 'user-1' })
+
+    expect(mockAdapter.cloneSessionTemplate).toHaveBeenCalledWith('st-1', 'user-1')
   })
 })

--- a/src/hooks/use-session-templates.ts
+++ b/src/hooks/use-session-templates.ts
@@ -85,6 +85,10 @@ export function useCloneSessionTemplate() {
       getAdapter().cloneSessionTemplate(id, userId),
     onError: (err) => {
       console.error('[session-templates] Failed to clone:', err)
+      toast('Failed to duplicate template. Please try again.')
+    },
+    onSuccess: () => {
+      toast('Template duplicated')
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['session-templates'] })

--- a/src/routes/_authenticated/library.tsx
+++ b/src/routes/_authenticated/library.tsx
@@ -399,6 +399,10 @@ function LibraryPage() {
                       template={template}
                       onEdit={() => handleEdit(template.id)}
                       onDelete={() => handleDelete(template.id)}
+                      onClone={() => cloneMutation.mutate({ id: template.id, userId })}
+                      isCloning={
+                        cloneMutation.isPending && cloneMutation.variables?.id === template.id
+                      }
                     />
                     {templateScope === 'public' && (
                       <TemplatePublicActions


### PR DESCRIPTION
## Summary
Add ability to duplicate session templates from the Library page, bringing parity with Event templates which already had this functionality.

## Context
Users could duplicate Event templates from the Library but had no way to duplicate regular session templates (Strength, Conditioning, SE, Mixed). The backend infrastructure (`cloneSessionTemplate` adapter method and `useCloneSessionTemplate` hook) was already implemented and working. The gap was purely in the UI layer for session templates.

## Changes
- Added `onClone` and `isCloning` optional props to `SessionTemplateCard` component
- Added a duplicate button (using `content_copy` icon) between the editable content area and the delete button
- Implemented loading state with `animate-pulse` and `opacity-50` classes during clone operation
- Wired clone handler in Library page to call `cloneMutation.mutate({ id, userId })` for session templates
- Added success toast notification: "Template duplicated"
- Added error toast notification: "Failed to duplicate template. Please try again."
- Added test coverage for `useCloneSessionTemplate` hook

### Key Implementation Details
The clone button follows the exact same pattern as `EventCard` for consistency:
- Uses `e.stopPropagation()` to prevent triggering the edit action when clicking clone
- Loading state is determined by `cloneMutation.isPending && cloneMutation.variables?.id === template.id`
- The adapter's `cloneSessionTemplate` method deep-clones the template, all activity groups, activities, and event items, appending "(Copy)" to the name

## Testing
```bash
# Run the specific hook tests
bun run test --run src/hooks/__tests__/use-session-templates.test.ts

# Run full test suite to verify no regressions
bun run test

# Build to verify TypeScript compilation
bun run build
```

All 2530 tests pass. The new test for `useCloneSessionTemplate` verifies that the hook calls `adapter.cloneSessionTemplate` with the correct arguments.

## Use Cases
1. User has a complex session template they want to modify without losing the original
   - Click duplicate icon on the template card
   - New template appears with "(Copy)" suffix
   - User can modify the copy without affecting the original

2. User wants to create variations of an existing template
   - Duplicate the template multiple times
   - Each copy gets "(Copy)" suffix (e.g., "Upper Body (Copy)")
   - User can then customize each variation independently

3. User accidentally clicks clone but doesn't want the duplicate
   - Delete the duplicate using the existing delete button
   - Original template remains unchanged
