### PR TITLE
fix(workout): snap timers to wall clock on mobile screen wake

### DIFF
--- a/Context/Reviews/0022-since-beta10-2026-04-22.md
+++ b/Context/Reviews/0022-since-beta10-2026-04-22.md
@@ -1,0 +1,228 @@
+# PR Review: Changes Since v1.0.0-beta.10
+
+**Date:** 2026-04-22
+**Scope:** All changes since tag `v1.0.0-beta.10` (24 commits, 119 source files)
+**Branch:** main
+**Reviewers:** code-reviewer, silent-failure-hunter, pr-test-analyzer, type-design-analyzer (automated agents)
+**Status:** 🟡 Partially resolved
+
+## Summary
+
+14 findings total: 9 [FIX], 3 [TASK], 0 [ADR], 0 [RULE]. 3 critical, 6 high, 5 medium/low.
+Coverage spans F021 (gym membership), F022 (browser notifications), F023 (exercise
+completion), F024 (frequent exercises), display-realtime collapse, data-mapper elimination,
+workout view split, and set UX overhaul. Test suite quality is notably strong in most areas;
+the main gap is `StrengthWorkoutView` (new finish guard has zero tests) and `EventWorkoutView`
+(new component, no test file).
+
+---
+
+## Findings
+
+### Fix-Now
+
+#### [FIX] P22-001: `getFrequentExerciseIds` swallows RPC error with `return []`
+- **File:** `src/lib/supabase-adapter.ts`
+- **Severity:** Critical
+- **Detail:** On RPC failure the function logs and returns `[]`, making a network error
+  indistinguishable from "user has no frequent exercises yet." TanStack Query reports
+  `isSuccess: true` with empty data; users who have frequent exercises see nothing and
+  receive no indication that something went wrong. Fix: `throw error` after logging so
+  `isError` propagates through the normal query error flow.
+- **Status:** ✅ Fixed
+- **Resolution:** Changed `return []` to `throw error` after logging. Updated test to assert rejection instead of empty return.
+
+#### [FIX] P22-002: `useGymRoster` null-client branch returns partial data inside `queryFn`
+- **File:** `src/hooks/use-gym-members.ts`
+- **Severity:** Critical
+- **Detail:** When the Supabase client is null, the `queryFn` returns augmented member
+  objects with `displayName: null` instead of throwing. `useQuery` reports `isSuccess: true`
+  with null display names on every roster member. Consumers cannot distinguish initialization
+  failure from "these members have no display names." A programmer-error condition should
+  surface as `isError`, not as silently degraded data. Fix: throw `new Error('[gym-members]
+  Supabase client not initialized')` so the error propagates correctly.
+- **Status:** ✅ Fixed
+- **Resolution:** Replaced the `return sorted.map(...)` fallback with `throw new Error('[gym-members] Supabase client not initialized')`.
+
+#### [FIX] P22-003: Duplicate error logging at 3 sites violates hook log ownership rule
+- **File:** `src/components/workout/strength-workout-view.tsx:425-444`, `src/routes/_authenticated/log.$workoutId.tsx:422-427`
+- **Severity:** High
+- **Detail:** Three catch blocks log the same rejection that the corresponding mutation hook
+  `onError` already logs: `deleteSet` (strength-workout-view:425), `removeActivity`
+  (strength-workout-view:438), and `handleUnconfirmSet` (log.$workoutId.tsx:422). This
+  produces two log lines with different `[module-name]` prefixes per failure, violating the
+  "Mutation Hook Log Ownership" rule in `.claude/rules/error-handling.md`. Fix: in each
+  catch block, keep `setPageError(...)` but drop the `console.error(...)` call -- the hook
+  already owns the log.
+- **Status:** ✅ Fixed
+- **Resolution:** Removed `console.error` from all three catch blocks; kept `setPageError` calls. Bare `catch {}` used where error param was only used for logging.
+
+#### [FIX] P22-004: `startProgrammedWorkout` store boundary validation removed
+- **File:** `src/stores/active-workout-store.ts`
+- **Severity:** High
+- **Detail:** The guard that threw when `workoutLog.programContext` was absent was removed
+  without a replacement invariant. The store no longer self-protects against non-programmed
+  logs being passed to `startProgrammedWorkout`. Per `.claude/rules/state-management.md`,
+  stores must validate at their own boundary. A future caller passing a non-programmed log
+  will corrupt workout state with no log or error. Fix: reinstate the `programContext` guard,
+  logging with `[active-workout]` prefix before returning.
+- **Status:** ✅ Deferred -- finding invalid
+- **Resolution:** An existing test explicitly documents that `startProgrammedWorkout` accepts logs without `programContext` (standalone template workouts). Adding the guard broke this intentional behavior. No fix applied; the finding conflicts with documented, tested behavior.
+
+#### [FIX] P22-005: `unconfirmSet` guard clause silently returns without user-facing error
+- **File:** `src/hooks/use-active-workout.ts`
+- **Severity:** High
+- **Detail:** When `findSetById` returns null, the handler logs `[workout] unconfirmSet: set
+  not found` and returns -- no toast, no error state. Per the "User-Action Guard Clauses"
+  rule in `.claude/rules/error-handling.md`, guard clauses in user-action handlers must
+  log AND set a user-facing error state. Users who tap "unconfirm" on a stale set ID get
+  no feedback and cannot tell whether their action registered. Fix: after the `console.error`,
+  surface an error via the existing page error mechanism or a toast.
+- **Status:** ✅ Fixed
+- **Resolution:** Changed `return` to `throw new Error('Set not found -- it may have already been removed.')`. The caller's existing catch block in `log.$workoutId.tsx` catches this and calls `setPageError`.
+
+#### [FIX] P22-006: Missing `.refine` cross-field invariants on gym domain types
+- **File:** `src/domain/types/gym.ts`
+- **Severity:** High
+- **Detail:** Three invariants are unenforced at the type level, inconsistent with the
+  `.refine` pattern already used on `WorkoutLog` (`completedAt > startedAt`):
+  1. `GymInvitation.usesCount <= maxUses` -- adapter bugs can silently produce over-capacity
+     invitations.
+  2. `GymInvitation.expiresAt > createdAt` -- an invite that expired before creation is
+     representable.
+  3. `GymOwnershipTransfer.proposedBy !== proposedTo` -- a self-transfer is a nonsensical
+     business state.
+  Additionally, `gymInvitationSchema` uses `token: z.string().min(1)` -- align minimum
+  length with the token generator (likely `min(16)` or UUID-length `min(36)`).
+- **Status:** ✅ Fixed
+- **Resolution:** Added `.refine` for all three invariants. Token min updated to `min(24)` to match DB constraint `char_length(token) >= 24` from `20260408000002_gym_membership_explicit.sql`.
+
+#### [FIX] P22-007: `addExerciseToWorkout` unused `_exercise` and `_groupType` parameters
+- **File:** `src/stores/active-workout-store.ts`
+- **Severity:** Low
+- **Detail:** Both parameters are prefixed `_` (intentionally unused) but appear on the
+  public action interface. Future authors reading the interface would believe they affect
+  store behavior; they do not -- the caller builds `newGroup` and `newActivity` before
+  calling the action. Fix: remove the unused parameters from the signature or use them
+  internally for validation/construction.
+- **Status:** ✅ Fixed
+- **Resolution:** Removed `exercise` and `groupType` from both the interface and implementation. Updated the call site in `use-active-workout.ts` and the test. Removed now-unused `Exercise` and `GroupType` imports from the store.
+
+#### [FIX] P22-008: Notification preference failure silently degrades rest timer
+- **File:** `src/hooks/use-active-workout.ts`
+- **Severity:** Medium
+- **Detail:** When notification preferences fail to load, the rest timer starts without the
+  `onExpired` callback -- rest-complete browser notifications are silently disabled for that
+  set. Athletes who rely on rest-complete notifications (e.g., phone face-down between sets)
+  miss them with no explanation. Fix: add a one-time toast such as "Rest notifications
+  unavailable -- check notification permissions" when the prefs fetch fails.
+- **Status:** ✅ Fixed
+- **Resolution:** Added `toast('Rest notifications unavailable -- check notification permissions.')` in the `.catch` block after starting the timer without the callback.
+
+#### [FIX] P22-009: `pendingDirty` not cleared on `handleMarkDone`
+- **File:** `src/components/workout/strength-workout-view.tsx`, `src/routes/_authenticated/__tests__/-log-workout-mark-done.test.tsx`
+- **Severity:** Medium
+- **Detail:** `handleMarkDone` clears `pendingInputs` for a skipped activity but does not
+  remove the activity's ID from `pendingDirty`. An athlete who edits a pending row and then
+  marks the exercise done will encounter the "You have unsaved data" finish guard dialog even
+  though the row is visually gone. The finish guard at line 143 checks `pendingDirty.size > 0`
+  with no awareness that the activity was skipped. Fix: clear the activity's ID from
+  `pendingDirty` in `handleMarkDone`, and add a test verifying a subsequent Finish tap
+  does not show the dirty dialog.
+- **Status:** ✅ Fixed
+- **Resolution:** Wrapped `onSkipExercise` in `strength-workout-view.tsx` to clear the activity's ID from `pendingDirty` before calling `handleMarkDone`. The regression test is tracked as S008-T in F023/Steps.md.
+
+---
+
+### Missing Tasks
+
+#### [TASK] P22-010: `StrengthWorkoutView` has no test file -- finish guard untested
+- **File:** `src/components/workout/strength-workout-view.tsx`
+- **Severity:** Critical
+- **Detail:** The `feat(workout): guard finish when pending set is dirtied` commit's core
+  behavior -- `handleFinishWithGuard`, `pendingDirty` accumulation, and clearing on confirm
+  or delete -- has zero test coverage. No test file exists for this component. Three paths
+  need explicit tests: (1) no dirty rows → `handleFinish()` called directly; (2) dirty row
+  present → `showFinishDirtyDialog` shown; (3) dirty row confirmed → subsequent Finish
+  proceeds without dialog. A regression here silently discards athlete set data.
+- **Relates to:** F023 exercise completion signal implementation
+- **Status:** ✅ Task created
+- **Resolution:** Added as S008-T in Context/Features/023-Exercise-Completion-Signal/Steps.md (Phase 6).
+
+#### [TASK] P22-011: `SetRow.onPendingDirty` prop never tested -- idempotency unverified
+- **File:** `src/components/workout/__tests__/set-row.test.tsx`
+- **Severity:** High
+- **Detail:** `markDirty` fires `onPendingDirty` on first edit of a pending row and is
+  intentionally idempotent (only calls once per row lifecycle). The existing `SetRow` tests
+  never pass `onPendingDirty` as a prop and never assert it is called. Needed: (1)
+  `onPendingDirty` called exactly once on first weight/reps edit of a pending row; (2) not
+  called on a confirmed (read-only) row; (3) not called a second time on subsequent field
+  edits. Without these, a loss of the `isDirty` guard would cause per-keystroke state churn
+  undetected.
+- **Relates to:** P22-010 (StrengthWorkoutView finish guard depends on this signal)
+- **Status:** ✅ Task created
+- **Resolution:** Added as S009-T in Context/Features/023-Exercise-Completion-Signal/Steps.md (Phase 6).
+
+#### [TASK] P22-012: `EventWorkoutView` has no tests
+- **File:** `src/components/workout/event-workout-view.tsx`
+- **Severity:** High
+- **Detail:** New component split from the workout route in this release has no test file.
+  The discard flow (dialog triggered via `WorkoutPausedBar.onDiscard`, Cancel vs Discard
+  paths), `canFinish={true}` semantics (always true, unlike `StrengthWorkoutView`'s
+  set-count gate), and `pageError` / `ErrorBanner` dismiss are all uncovered. Without tests,
+  a future unification of the two workout views could accidentally gate event workout
+  finishing behind a set count.
+- **Status:** ✅ Task created
+- **Resolution:** Added as S010-T in Context/Features/023-Exercise-Completion-Signal/Steps.md (Phase 6).
+
+#### [TASK] P22-013: `allActivitiesDone` mixed CIRCUIT + STRENGTH finish-banner scenario untested
+- **File:** `src/routes/_authenticated/__tests__/-log-workout-finish-banner.test.tsx`
+- **Severity:** Medium
+- **Detail:** The existing test covers CIRCUIT-only (banner shows when only CIRCUIT groups
+  remain). The mixed case -- one CIRCUIT group with incomplete activities plus one STRENGTH
+  group fully done -- is not tested. In this scenario `allActivitiesDone` should be `true`
+  because CIRCUIT groups are excluded from the check. If the exclusion filter regresses,
+  the "READY TO FINISH?" banner never appears for concurrent-training workouts. Add a test
+  case with at least one CIRCUIT and one STRENGTH group where all STRENGTH activities are
+  done.
+- **Status:** ✅ Task created
+- **Resolution:** Added as S011-T in Context/Features/023-Exercise-Completion-Signal/Steps.md (Phase 6).
+
+---
+
+## Positive Observations
+
+- `active-workout-store-rest-expired.test.ts` is a precise behavioral specification: once-only
+  callback firing, non-firing on `skipRest`, cleanup/finish/discard no-call guarantees all
+  verified.
+- `display-realtime.test.ts` covers all five reconnect error status paths, exponential
+  backoff, gym-switch channel teardown, and auto-`publishHello` on reconnect. Boundary
+  validation tests directly enforce the `state-management.md` module-boundary rule.
+- `use-session-reminder-browser.test.ts` covers all six disabling conditions, once-per-day
+  deduplication, and Tauri no-op path. The asymmetry between rest-timer (not blocked by quiet
+  hours) and session-reminder (blocked) is explicitly verified.
+- `RedeemInviteError` and `GymMemberCount` are well-specified types with no identified gaps.
+- Data-mapper elimination is clean: no orphaned consumers, `notes`/`noteTags` removal from
+  `LoggedSet` is complete with no downstream breakage.
+
+---
+
+## Resolution Checklist
+
+- [x] All [FIX] findings resolved (P22-001 through P22-009)
+- [x] All [TASK] findings added to Steps.md or addressed (P22-010 through P22-013)
+- [x] Review verified by review-verify agent
+
+---
+
+## Resolution Summary
+**Resolved at:** 2026-04-22
+**Session:** P22 batch review -- changes since v1.0.0-beta.10
+
+| Category | Total | Resolved | Deferred |
+|---|---|---|---|
+| [FIX] | 9 | 8 | 1 |
+| [TASK] | 4 | 4 | 0 |
+| **Total** | **13** | **12** | **1** |
+
+**Deferred:** P22-004 -- finding invalid; existing test documents that `startProgrammedWorkout` intentionally accepts standalone template workouts without `programContext`.

--- a/Context/Reviews/0023-pr116-timer-timeout-2026-04-22.md
+++ b/Context/Reviews/0023-pr116-timer-timeout-2026-04-22.md
@@ -1,0 +1,195 @@
+# PR Review: fix/timer-timeout → develop
+
+**Date:** 2026-04-22
+**Feature:** (fix branch -- no feature directory)
+**Branch:** fix/timer-timeout
+**PR:** #116 -- fix(workout): snap timers to wall clock on mobile screen wake
+**Reviewers:** code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer
+**Status:** ✅ Resolved
+
+## Summary
+
+13 findings across Fix-Now (11) and Missing Tasks (2). Core approach is architecturally
+sound and the math is correct. Three critical issues must be fixed before merge: a Tauri
+listener race condition that can instantly expire a newly started timer, a store corruption
+path when `_onRestExpired` throws, and a bare `catch {}` violating the error-handling rule.
+All suggestions captured.
+
+## Findings
+
+### Fix-Now
+
+#### [FIX] P23-001: recalcRestTimer expiry path does not stop Rust timer or clean listeners (Tauri mode)
+- **File:** `src/stores/active-workout-store.ts:702-712`
+- **Severity:** Critical
+- **Detail:** When `recalcRestTimer()` fires expiry in Tauri mode it sets `restTimer: null`
+  but does not call `invoke('skip_rest_timer')` or `_cleanupTauriRestListeners()`. The Rust
+  tokio task keeps running. When it emits `timer_expired` (~1s later), the still-registered
+  listener fires. If the user starts a new rest timer in that window, `startRestTimer`'s
+  entry-point `_cleanupTauriRestListeners()` races with the orphaned Rust event -- the new
+  timer can vanish immediately with no log trace. This is the exact screen-wake scenario the
+  PR targets. Fix: mirror `skipRest()` -- call `invoke('skip_rest_timer')` and
+  `_cleanupTauriRestListeners()` in the expiry branch of `recalcRestTimer`.
+- **Status:** ✅ Fixed
+- **Resolution:** Added `isTauri()` branch in `recalcRestTimer` expiry path that calls `invoke('skip_rest_timer')` and `_cleanupTauriRestListeners()`, mirroring `skipRest()`.
+
+#### [FIX] P23-002: _onRestExpired throw in recalcRestTimer corrupts store state and causes double-fire
+- **File:** `src/stores/active-workout-store.ts:703`
+- **Severity:** Critical
+- **Detail:** If `_onRestExpired?.()` throws, all following cleanup lines are skipped:
+  `_onRestExpired` is not nulled, `_restInterval` is not cleared, `restTimer` is not set to
+  null. The interval keeps ticking, hits the same expiry branch on the next tick, and fires
+  the callback a second time. UI freezes at 0:00. Fix: wrap callback in `try/catch` and do
+  all cleanup unconditionally in a `finally` block. The pre-existing identical flaw in
+  `tickRest` (lines 679-688) should be fixed at the same time.
+- **Status:** ✅ Fixed
+- **Resolution:** Wrapped `_onRestExpired?.()` in `try/catch/finally` in both `recalcRestTimer` and `tickRest`; cleanup always runs, callback errors are logged and swallowed.
+
+#### [FIX] P23-003: tickRest() has same _onRestExpired callback throw flaw (pre-existing)
+- **File:** `src/stores/active-workout-store.ts:679`
+- **Severity:** High
+- **Detail:** Pre-existing version of P23-002 in `tickRest`. The PR introduced `recalcRestTimer`
+  modeled on `tickRest` without fixing the original. Both should get the `try/finally` wrapper
+  in the same pass.
+- **Status:** ✅ Fixed
+- **Resolution:** Fixed as part of P23-002 -- both `tickRest` and `recalcRestTimer` got `try/catch/finally`.
+
+#### [FIX] P23-004: Bare `catch {}` violates .claude/rules/error-handling.md
+- **File:** `src/routes/_authenticated/log.$workoutId.tsx:245`
+- **Severity:** Critical
+- **Detail:** The foreground callback contains `} catch { // Non-critical -- interval will
+  self-correct on next tick. }`. The project rule is unconditional: "Never use bare `catch {}`.
+  Always capture the error parameter and log it with a bracketed module prefix." The "non-critical"
+  comment is editorial -- not a rule exception. Fix:
+  `} catch (err) { console.error('[workout-log] Foreground elapsed snap failed:', err) }`
+- **Status:** ✅ Fixed
+- **Resolution:** Changed to `catch (err) { console.error('[workout-log] Foreground elapsed snap failed:', err) }`.
+
+#### [FIX] P23-005: store.recalcRestTimer() call is outside try/catch in foreground callback
+- **File:** `src/routes/_authenticated/log.$workoutId.tsx:249`
+- **Severity:** High
+- **Detail:** The `try/catch` on lines 238-247 protects only the elapsed snap.
+  `store.recalcRestTimer()` on line 249 is outside it. If `recalcRestTimer` throws, the
+  exception is silently absorbed by the `visibilitychange` event system -- no console output,
+  no user notice, rest timer snap silently fails on screen wake. Fix: wrap in its own
+  `try/catch` with a logged error `[workout-log]`.
+- **Status:** ✅ Fixed
+- **Resolution:** Wrapped `store.recalcRestTimer()` in its own `try/catch` with `console.error('[workout-log] recalcRestTimer failed on foreground:', err)`.
+
+#### [FIX] P23-006: tickRest() still uses tick-accumulation, asymmetric with the wall-clock fix
+- **File:** `src/stores/active-workout-store.ts:675`
+- **Severity:** Medium
+- **Detail:** All other timer paths (Rust loop, recalcRestTimer, adjustRest, foreground snap)
+  now use wall-clock computation. `tickRest` still does `remaining - 1`. For backgrounded
+  browser tabs (not just screen-off), drift accumulates between foreground events. `startedAt`
+  and `total` are already in state, so `tickRest` can compute remaining directly:
+  `Math.max(0, Math.round(state.restTimer.total - (Date.now() - state.restTimer.startedAt) / 1000))`
+- **Status:** ✅ Fixed
+- **Resolution:** Changed `tickRest` to compute `newRemaining` from `total - (Date.now() - startedAt) / 1000`; updated existing tests to advance system time before ticking.
+
+#### [FIX] P23-007: Rust adjust tests have timing race on slow CI
+- **File:** `src-tauri/src/rest_timer.rs` -- `adjust_positive_increments_total_and_remaining`
+  and `adjust_negative_decrements_remaining_only` tests
+- **Severity:** Medium
+- **Detail:** Both tests set `started_at = Instant::now()` and then assert `remaining == 70`
+  / `remaining == 50`. If >1 second elapses during the test (async lock contention, slow CI),
+  `elapsed().as_secs() as u32` becomes 1 and the assertion fails non-deterministically. The
+  `saturates_to_zero` test correctly pre-sets `started_at` to a fixed offset -- apply the
+  same approach (or tolerance assertions) to the other two tests.
+- **Status:** ✅ Fixed
+- **Resolution:** Changed `assert_eq!` to tolerance assertions (`remaining >= N-1 && remaining <= N`) with explanatory messages for both tests.
+
+#### [FIX] P23-010: Empty onBackground callback should have an explanatory comment
+- **File:** `src/routes/_authenticated/log.$workoutId.tsx:251`
+- **Severity:** Low
+- **Detail:** The `() => {}` passed as `onBackground` to `createForegroundDetector` is
+  intentionally a no-op but reads as an oversight without a comment. Suggested:
+  `() => { /* No-op: timers use wall-clock timestamps, nothing to freeze on screen-off. */ }`
+- **Status:** ✅ Fixed
+- **Resolution:** Added the suggested comment to the `onBackground` no-op callback.
+
+#### [FIX] P23-011: Rust adjust() unwrap_or_else fallback lacks comment explaining saturation semantics
+- **File:** `src-tauri/src/rest_timer.rs:144-146`
+- **Severity:** Low
+- **Detail:** The fallback `Instant::now() - Duration::from_secs(inner.total as u64)` sets
+  `started_at` so that `elapsed == total`, making `remaining == 0`. This is intentional
+  saturation-to-zero behavior for overshooting deltas, but there is no comment naming that
+  intent. Add: `// Fallback: saturate to remaining=0 if delta would exceed total elapsed`.
+- **Status:** ✅ Fixed
+- **Resolution:** Added `// Fallback: saturate to remaining=0 if delta would exceed total elapsed` comment before the `unwrap_or_else` fallback.
+
+#### [FIX] P23-012: recalcRestTimer interface comment omits the main "timer still running" path
+- **File:** `src/stores/active-workout-store.ts` (interface declaration for `recalcRestTimer`)
+- **Severity:** Low
+- **Detail:** The comment only mentions the expiry case ("Fires onExpired if the rest period
+  ended while the screen was dark") but the common execution path -- update `remaining` to
+  wall-clock value when the timer is still running -- is undocumented. Rewrite to describe
+  both paths: "Recalculates remaining time from wall-clock elapsed. If the rest period has
+  ended, fires onExpired and clears the timer. Safe to call anytime the timer may have drifted."
+- **Status:** ✅ Fixed
+- **Resolution:** Rewrote interface comment to document both paths (running: correct remaining; expired: fire onExpired + clear timer).
+
+#### [FIX] P23-013: adjustRest inline comment overstates Rust parity on large-negative-delta saturation
+- **File:** `src/stores/active-workout-store.ts:588-590`
+- **Severity:** Low
+- **Detail:** Comment claims behavior "matches Rust behavior" for both delta directions. The
+  observable result matches, but the mechanism differs: Rust saturates `started_at` via
+  `checked_sub` (clamping the instant); JS saturates via `Math.max(0, ...)` on `remaining`,
+  leaving `startedAt` at an over-shifted value in state. A future maintainer who relies on
+  `startedAt` being valid after a large negative adjust could be misled. Add a qualifier:
+  "Note: Rust saturates via checked_sub on started_at; JS saturates via Math.max on remaining."
+- **Status:** ✅ Fixed
+- **Resolution:** Updated comment to note the mechanism difference between Rust (`checked_sub` on `started_at`) and JS (`Math.max` on `remaining`).
+
+### Missing Tasks
+
+#### [TASK] P23-008: recalcRestTimer() has zero test coverage
+- **File:** `src/stores/__tests__/active-workout-store-rest-expired.test.ts`
+- **Severity:** Critical
+- **Detail:** `recalcRestTimer()` is the entire JS path of this fix but has no tests. Two
+  behavioral branches need coverage: (A) timer expired while screen was off -- `onExpired`
+  fires, `restTimer` becomes null; (B) timer still running -- `remaining` is corrected to
+  wall-clock value. The `active-workout-store-rest-expired.test.ts` file already has
+  `vi.useFakeTimers()` scaffolding and is the right place. Example:
+  - Timer expired path: `vi.setSystemTime(start + 90_000)` after starting 60s timer, then
+    call `recalcRestTimer()`, assert `onExpired` called once and `restTimer` is null.
+  - Timer running path: `vi.setSystemTime(start + 20_000)`, call `recalcRestTimer()`,
+    assert `remaining == 40`.
+  - No-op when `restTimer` is null.
+  - Boundary: exactly at expiry (t + 60_000 ms for a 60s timer).
+- **Status:** ✅ Task created (written directly)
+- **Resolution:** Added 4 `recalcRestTimer` tests: expired path, running path, no-op when null, exact expiry boundary. Also added 2 throwing-callback tests (tickRest + recalcRestTimer) covering the P23-002/003 fix.
+
+#### [TASK] P23-009: adjustRest tests don't verify startedAt mutation under wall-clock approach
+- **File:** `src/stores/__tests__/active-workout-store-rest-expired.test.ts`
+- **Severity:** Low
+- **Detail:** Existing `adjustRest` tests check `remaining` and `total` after adjustment but
+  not whether `startedAt` was correctly shifted. For negative delta, the implementation shifts
+  `startedAt` earlier by `(-delta) * 1000` ms. If a future refactor silently falls back to
+  direct `remaining` mutation (skipping the shift), tests still pass because `remaining` is
+  recomputed from the shifted values immediately. A test that also verifies `startedAt` was
+  mutated correctly -- or that pairs `adjustRest(-30)` with a follow-up `recalcRestTimer()`
+  call -- would protect the wall-clock contract.
+- **Status:** ✅ Task created (written directly)
+- **Resolution:** Added `adjustRest negative delta shifts startedAt earlier and wall-clock recalc confirms it` test verifying both the `startedAt` shift and follow-up `recalcRestTimer` convergence.
+
+---
+
+## Resolution Checklist
+- [x] All [FIX] findings resolved (P23-001 through P23-007, P23-010 through P23-013)
+- [x] All [TASK] findings written directly as tests (P23-008, P23-009)
+- [x] All [ADR] findings have ADRs created or dismissed (none)
+- [x] All [RULE] findings applied or dismissed (none)
+- [ ] Review verified by review-verify agent
+
+## Resolution Summary
+**Resolved at:** 2026-04-22
+**Session:** fix/timer-timeout review resolution
+
+| Category | Total | Resolved |
+|---|---|---|
+| [FIX] | 11 | 11 |
+| [TASK] | 2 | 2 |
+| [ADR] | 0 | 0 |
+| [RULE] | 0 | 0 |
+| **Total** | **13** | **13** |

--- a/Context/Reviews/0023-pr116-timer-timeout-2026-04-22.md
+++ b/Context/Reviews/0023-pr116-timer-timeout-2026-04-22.md
@@ -180,7 +180,7 @@ All suggestions captured.
 - [x] All [TASK] findings written directly as tests (P23-008, P23-009)
 - [x] All [ADR] findings have ADRs created or dismissed (none)
 - [x] All [RULE] findings applied or dismissed (none)
-- [ ] Review verified by review-verify agent
+- [x] Review verified by review-verify agent
 
 ## Resolution Summary
 **Resolved at:** 2026-04-22

--- a/src-tauri/src/rest_timer.rs
+++ b/src-tauri/src/rest_timer.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -10,9 +11,9 @@ use crate::notification;
 const REST_TIMER_NOTIFICATION_ID: i32 = 1001;
 
 pub struct RestTimerInner {
-    pub remaining: u32,
     pub total: u32,
     pub active: bool,
+    pub started_at: Instant,
     pub exercise_name: Option<String>,
     pub set_number: Option<u32>,
 }
@@ -26,9 +27,9 @@ impl RestTimerState {
     pub fn new() -> Self {
         Self {
             inner: Arc::new(Mutex::new(RestTimerInner {
-                remaining: 0,
                 total: 0,
                 active: false,
+                started_at: Instant::now(),
                 exercise_name: None,
                 set_number: None,
             })),
@@ -51,9 +52,9 @@ impl RestTimerState {
 
         {
             let mut inner = self.inner.lock().await;
-            inner.remaining = seconds;
             inner.total = seconds;
             inner.active = true;
+            inner.started_at = Instant::now();
             inner.exercise_name = exercise_name;
             inner.set_number = set_number;
         }
@@ -70,11 +71,10 @@ impl RestTimerState {
                     break;
                 }
 
-                if guard.remaining > 0 {
-                    guard.remaining -= 1;
-                }
-
-                let remaining = guard.remaining;
+                // Compute remaining from wall clock so the timer self-corrects
+                // after the app is backgrounded (screen off) on mobile.
+                let elapsed = guard.started_at.elapsed().as_secs() as u32;
+                let remaining = guard.total.saturating_sub(elapsed);
                 let total = guard.total;
                 drop(guard);
 
@@ -93,7 +93,6 @@ impl RestTimerState {
                         log::error!("[rest-timer] Failed to emit timer_expired: {e}");
                     }
 
-                    // Build context-aware notification body
                     let mut guard = inner.lock().await;
                     let body = match (&guard.exercise_name, guard.set_number) {
                         (Some(name), Some(num)) => format!("{name} -- Set {num}"),
@@ -136,11 +135,15 @@ impl RestTimerState {
     pub async fn adjust(&self, delta: i32) {
         let mut inner = self.inner.lock().await;
         if delta >= 0 {
-            inner.remaining = inner.remaining.saturating_add(delta as u32);
+            // Extend total so remaining increases by delta.
             inner.total = inner.total.saturating_add(delta as u32);
         } else {
-            let abs_delta = (-delta) as u32;
-            inner.remaining = inner.remaining.saturating_sub(abs_delta);
+            // Shrink remaining by shifting started_at earlier (more elapsed).
+            let abs_delta = (-delta) as u64;
+            let new_elapsed = inner.started_at.elapsed() + Duration::from_secs(abs_delta);
+            inner.started_at = Instant::now()
+                .checked_sub(new_elapsed)
+                .unwrap_or_else(|| Instant::now() - Duration::from_secs(inner.total as u64));
         }
     }
 }
@@ -160,18 +163,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn adjust_positive_increments_both_remaining_and_total() {
+    async fn adjust_positive_increments_total_and_remaining() {
         let timer = make_timer();
         {
             let mut inner = timer.inner.lock().await;
-            inner.remaining = 60;
+            inner.started_at = Instant::now();
             inner.total = 60;
             inner.active = true;
         }
         timer.adjust(10).await;
         let inner = timer.inner.lock().await;
-        assert_eq!(inner.remaining, 70);
         assert_eq!(inner.total, 70);
+        let remaining = inner.total.saturating_sub(inner.started_at.elapsed().as_secs() as u32);
+        assert_eq!(remaining, 70);
     }
 
     #[tokio::test]
@@ -179,14 +183,15 @@ mod tests {
         let timer = make_timer();
         {
             let mut inner = timer.inner.lock().await;
-            inner.remaining = 60;
+            inner.started_at = Instant::now();
             inner.total = 60;
             inner.active = true;
         }
         timer.adjust(-10).await;
         let inner = timer.inner.lock().await;
-        assert_eq!(inner.remaining, 50);
         assert_eq!(inner.total, 60);
+        let remaining = inner.total.saturating_sub(inner.started_at.elapsed().as_secs() as u32);
+        assert_eq!(remaining, 50);
     }
 
     #[tokio::test]
@@ -194,14 +199,16 @@ mod tests {
         let timer = make_timer();
         {
             let mut inner = timer.inner.lock().await;
-            inner.remaining = 30;
+            // Simulate 30s already elapsed: started 30s ago, total=60 → remaining=30
+            inner.started_at = Instant::now() - Duration::from_secs(30);
             inner.total = 60;
             inner.active = true;
         }
         timer.adjust(-100).await;
         let inner = timer.inner.lock().await;
-        assert_eq!(inner.remaining, 0);
         assert_eq!(inner.total, 60);
+        let remaining = inner.total.saturating_sub(inner.started_at.elapsed().as_secs() as u32);
+        assert_eq!(remaining, 0);
     }
 
     #[tokio::test]

--- a/src-tauri/src/rest_timer.rs
+++ b/src-tauri/src/rest_timer.rs
@@ -141,6 +141,7 @@ impl RestTimerState {
             // Shrink remaining by shifting started_at earlier (more elapsed).
             let abs_delta = (-delta) as u64;
             let new_elapsed = inner.started_at.elapsed() + Duration::from_secs(abs_delta);
+            // Fallback: saturate to remaining=0 if delta would exceed total elapsed.
             inner.started_at = Instant::now()
                 .checked_sub(new_elapsed)
                 .unwrap_or_else(|| Instant::now() - Duration::from_secs(inner.total as u64));
@@ -175,7 +176,8 @@ mod tests {
         let inner = timer.inner.lock().await;
         assert_eq!(inner.total, 70);
         let remaining = inner.total.saturating_sub(inner.started_at.elapsed().as_secs() as u32);
-        assert_eq!(remaining, 70);
+        // Allow 1s tolerance: elapsed may advance to 1s on slow CI before assertion.
+        assert!(remaining >= 69 && remaining <= 70, "expected remaining ~70, got {remaining}");
     }
 
     #[tokio::test]
@@ -191,7 +193,8 @@ mod tests {
         let inner = timer.inner.lock().await;
         assert_eq!(inner.total, 60);
         let remaining = inner.total.saturating_sub(inner.started_at.elapsed().as_secs() as u32);
-        assert_eq!(remaining, 50);
+        // Allow 1s tolerance: elapsed may advance to 1s on slow CI before assertion.
+        assert!(remaining >= 49 && remaining <= 50, "expected remaining ~50, got {remaining}");
     }
 
     #[tokio::test]

--- a/src/routes/_authenticated/log.$workoutId.tsx
+++ b/src/routes/_authenticated/log.$workoutId.tsx
@@ -244,13 +244,17 @@ function ActiveWorkoutPage() {
             const elapsedMs = now - startedMs - totalPausedMs
             store.setElapsedSeconds(Math.max(0, Math.round(elapsedMs / 1000)))
           }
-        } catch {
-          // Non-critical -- interval will self-correct on next tick.
+        } catch (err) {
+          console.error('[workout-log] Foreground elapsed snap failed:', err)
         }
         // Snap rest timer to wall-clock reality, firing onExpired if needed.
-        store.recalcRestTimer()
+        try {
+          store.recalcRestTimer()
+        } catch (err) {
+          console.error('[workout-log] recalcRestTimer failed on foreground:', err)
+        }
       },
-      () => {},
+      () => { /* No-op: timers use wall-clock timestamps, nothing to freeze on screen-off. */ },
     )
     detector.start()
     return () => detector.stop()

--- a/src/routes/_authenticated/log.$workoutId.tsx
+++ b/src/routes/_authenticated/log.$workoutId.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { isTauri } from '@tauri-apps/api/core'
+import { createForegroundDetector } from '@/lib/foreground-detector'
 import { useActiveWorkout } from '@/hooks/use-active-workout'
 import { useActiveWorkoutStore } from '@/stores/active-workout-store'
 import { useExercises } from '@/hooks/use-exercises'
@@ -218,13 +219,41 @@ function ActiveWorkoutPage() {
     if (pausedAt) return
 
     const intervalId = setInterval(() => {
-      const prev = useActiveWorkoutStore.getState().elapsedSeconds
-      useActiveWorkoutStore.getState().setElapsedSeconds(prev + 1)
+      setElapsedSeconds(computeElapsed())
     }, 1000)
 
     return () => {
       clearInterval(intervalId)
     }
+  }, [workoutLogId, startedAt, totalPausedMs, pausedAt])
+
+  // ---------------------------------------------------------------------------
+  // Foreground detection -- snap timers when screen wakes after timeout
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (!workoutLogId || !startedAt || pausedAt) return
+
+    const detector = createForegroundDetector(
+      () => {
+        // Snap elapsed timer immediately rather than waiting for the next tick.
+        const store = useActiveWorkoutStore.getState()
+        try {
+          const startedMs = new Date(startedAt).getTime()
+          if (Number.isFinite(startedMs)) {
+            const now = Date.now()
+            const elapsedMs = now - startedMs - totalPausedMs
+            store.setElapsedSeconds(Math.max(0, Math.round(elapsedMs / 1000)))
+          }
+        } catch {
+          // Non-critical -- interval will self-correct on next tick.
+        }
+        // Snap rest timer to wall-clock reality, firing onExpired if needed.
+        store.recalcRestTimer()
+      },
+      () => {},
+    )
+    detector.start()
+    return () => detector.stop()
   }, [workoutLogId, startedAt, totalPausedMs, pausedAt])
 
   // Count confirmed sets to determine if FINISH should be enabled

--- a/src/stores/__tests__/active-workout-store-rest-expired.test.ts
+++ b/src/stores/__tests__/active-workout-store-rest-expired.test.ts
@@ -91,22 +91,26 @@ afterEach(() => {
 describe('_onRestExpired callback', () => {
   it('onExpired callback fires exactly once when browser timer counts to zero', () => {
     const onExpired = vi.fn()
+    const start = Date.now()
 
     getState().startRestTimer(3, undefined, undefined, onExpired)
 
-    // Tick 1: remaining 3 -> 2
+    // Tick 1: 1s elapsed, remaining -> 2
+    vi.setSystemTime(start + 1000)
     getState().tickRest()
     expect(onExpired).not.toHaveBeenCalled()
     expect(getState().restTimer).not.toBeNull()
     expect(getState().restTimer!.remaining).toBe(2)
 
-    // Tick 2: remaining 2 -> 1
+    // Tick 2: 2s elapsed, remaining -> 1
+    vi.setSystemTime(start + 2000)
     getState().tickRest()
     expect(onExpired).not.toHaveBeenCalled()
     expect(getState().restTimer).not.toBeNull()
     expect(getState().restTimer!.remaining).toBe(1)
 
-    // Tick 3: remaining 1 -> 0, callback fires and timer clears
+    // Tick 3: 3s elapsed, remaining -> 0, callback fires and timer clears
+    vi.setSystemTime(start + 3000)
     getState().tickRest()
     expect(onExpired).toHaveBeenCalledTimes(1)
     expect(getState().restTimer).toBeNull()
@@ -132,14 +136,15 @@ describe('_onRestExpired callback', () => {
     const callbackA = vi.fn()
     const callbackB = vi.fn()
 
-    // Start timer with callback A
+    // Start timer with callback A, then immediately replace with callback B
     getState().startRestTimer(5, undefined, undefined, callbackA)
-
-    // Start a new timer with callback B before A expires
+    const start = Date.now()
     getState().startRestTimer(2, undefined, undefined, callbackB)
 
     // Tick to zero (2 ticks for the second timer)
+    vi.setSystemTime(start + 1000)
     getState().tickRest()
+    vi.setSystemTime(start + 2000)
     getState().tickRest()
 
     // Only callback B should have been called
@@ -165,12 +170,49 @@ describe('_onRestExpired callback', () => {
   })
 
   it('onExpired is null when no callback provided -- ticking to zero does not throw', () => {
-    // Start rest timer without onExpired parameter
+    const start = Date.now()
     getState().startRestTimer(1)
 
-    // Tick to zero -- the ?. operator should handle null gracefully
+    // Advance to expiry and tick -- the ?. operator should handle null gracefully
+    vi.setSystemTime(start + 1000)
     expect(() => getState().tickRest()).not.toThrow()
     expect(getState().restTimer).toBeNull()
+  })
+
+  it('onExpired throwing during tickRest still clears timer state', () => {
+    const throwing = vi.fn().mockImplementation(() => {
+      throw new Error('callback error')
+    })
+    const start = Date.now()
+    getState().startRestTimer(1, undefined, undefined, throwing)
+
+    // Advance to expiry -- error is caught internally, does not propagate
+    vi.setSystemTime(start + 1000)
+    expect(() => getState().tickRest()).not.toThrow()
+    expect(getState().restTimer).toBeNull()
+    expect(throwing).toHaveBeenCalledTimes(1)
+
+    // Subsequent ticks must not fire the callback again
+    getState().tickRest()
+    expect(throwing).toHaveBeenCalledTimes(1)
+  })
+
+  it('onExpired throwing during recalcRestTimer still clears timer state', () => {
+    const throwing = vi.fn().mockImplementation(() => {
+      throw new Error('callback error')
+    })
+    const start = Date.now()
+    getState().startRestTimer(60, undefined, undefined, throwing)
+
+    // Advance clock past expiry -- error is caught internally, does not propagate
+    vi.setSystemTime(start + 70_000)
+    expect(() => getState().recalcRestTimer()).not.toThrow()
+    expect(getState().restTimer).toBeNull()
+    expect(throwing).toHaveBeenCalledTimes(1)
+
+    // Subsequent calls must be no-ops
+    getState().recalcRestTimer()
+    expect(throwing).toHaveBeenCalledTimes(1)
   })
 
   it('finishWorkout clears onExpired without calling it', () => {
@@ -190,6 +232,69 @@ describe('_onRestExpired callback', () => {
     expect(onExpired).not.toHaveBeenCalled()
     expect(getState().restTimer).toBeNull()
     expect(getState().workoutLog).toBeNull()
+  })
+
+  it('recalcRestTimer fires onExpired and nulls restTimer when timer expired', () => {
+    const onExpired = vi.fn()
+    const start = Date.now()
+    getState().startRestTimer(60, undefined, undefined, onExpired)
+
+    // Advance clock past expiry
+    vi.setSystemTime(start + 70_000)
+
+    getState().recalcRestTimer()
+
+    expect(onExpired).toHaveBeenCalledTimes(1)
+    expect(getState().restTimer).toBeNull()
+  })
+
+  it('recalcRestTimer corrects remaining to wall-clock value when timer still running', () => {
+    const start = Date.now()
+    getState().startRestTimer(60)
+
+    // Advance clock by 20s
+    vi.setSystemTime(start + 20_000)
+
+    getState().recalcRestTimer()
+
+    expect(getState().restTimer).not.toBeNull()
+    expect(getState().restTimer!.remaining).toBe(40)
+  })
+
+  it('recalcRestTimer is a no-op when restTimer is null', () => {
+    expect(getState().restTimer).toBeNull()
+    expect(() => getState().recalcRestTimer()).not.toThrow()
+  })
+
+  it('recalcRestTimer fires onExpired at exact expiry boundary', () => {
+    const onExpired = vi.fn()
+    const start = Date.now()
+    getState().startRestTimer(60, undefined, undefined, onExpired)
+
+    vi.setSystemTime(start + 60_000)
+
+    getState().recalcRestTimer()
+
+    expect(onExpired).toHaveBeenCalledTimes(1)
+    expect(getState().restTimer).toBeNull()
+  })
+
+  it('adjustRest negative delta shifts startedAt earlier and wall-clock recalc confirms it', () => {
+    const start = Date.now()
+    getState().startRestTimer(60)
+
+    getState().adjustRest(-30)
+
+    const timer = getState().restTimer!
+    // startedAt should have been shifted 30s into the past
+    expect(timer.startedAt).toBeLessThanOrEqual(start - 30_000 + 50) // 50ms tolerance
+
+    // Wall-clock recalc after the shift should yield ~30s remaining
+    vi.setSystemTime(start)
+    getState().recalcRestTimer()
+    const afterRecalc = getState().restTimer!
+    expect(afterRecalc.remaining).toBeGreaterThanOrEqual(29)
+    expect(afterRecalc.remaining).toBeLessThanOrEqual(30)
   })
 
   it('discardWorkout clears onExpired without calling it', () => {

--- a/src/stores/__tests__/active-workout-store.test.ts
+++ b/src/stores/__tests__/active-workout-store.test.ts
@@ -4,7 +4,6 @@ import type {
   LoggedActivityGroup,
   LoggedActivity,
   LoggedSet,
-  Exercise,
   GroupType,
 } from '@/domain/types'
 import type { LoggedActivityGroupWithActivities } from '@/stores/active-workout-store'
@@ -55,24 +54,6 @@ function makeLoggedSet(overrides?: Partial<LoggedSet>): LoggedSet {
     completed: false,
     ...overrides,
   } as LoggedSet
-}
-
-function makeExercise(overrides?: Partial<Exercise>): Exercise {
-  return {
-    id: 'ex-1',
-    createdAt: NOW,
-    updatedAt: NOW,
-    name: 'Bench Press',
-    aliases: [],
-    category: 'BARBELL',
-    movementPattern: 'PUSH',
-    muscleGroups: { primary: ['CHEST'], secondary: ['TRICEPS'] },
-    isBilateral: true,
-    supports1RM: true,
-    equipmentRequired: ['BARBELL', 'BENCH'],
-    isCustom: false,
-    ...overrides,
-  } as Exercise
 }
 
 function makeGroupWithActivities(

--- a/src/stores/__tests__/active-workout-store.test.ts
+++ b/src/stores/__tests__/active-workout-store.test.ts
@@ -275,18 +275,24 @@ describe('rest timer', () => {
     expect(restTimer!.total).toBe(90)
   })
 
-  it('tickRest decrements remaining by 1', () => {
+  it('tickRest corrects remaining to wall-clock value', () => {
     getState().startRestTimer(90)
+    // Shift startedAt back 1s to simulate 1s of elapsed time
+    useActiveWorkoutStore.setState((s) => ({
+      restTimer: s.restTimer ? { ...s.restTimer, startedAt: s.restTimer.startedAt - 1000 } : null,
+    }))
     getState().tickRest()
 
     expect(getState().restTimer!.remaining).toBe(89)
     expect(getState().restTimer!.total).toBe(90)
   })
 
-  it('tickRest clears restTimer when remaining reaches 0', () => {
+  it('tickRest clears restTimer when elapsed exceeds total', () => {
     getState().startRestTimer(1)
-
-    // One tick brings remaining to 0 (or below), triggering auto-clear
+    // Shift startedAt back 2s so the timer has expired
+    useActiveWorkoutStore.setState((s) => ({
+      restTimer: s.restTimer ? { ...s.restTimer, startedAt: s.restTimer.startedAt - 2000 } : null,
+    }))
     getState().tickRest()
 
     expect(getState().restTimer).toBeNull()

--- a/src/stores/active-workout-store.ts
+++ b/src/stores/active-workout-store.ts
@@ -168,9 +168,9 @@ interface ActiveWorkoutActions {
   ): void
   skipRest(): void
   adjustRest(delta: number): void
-  // Snaps the rest timer to wall-clock reality -- called by the foreground
-  // detector when the screen wakes after being off. Fires onExpired if the
-  // rest period ended while the screen was dark.
+  // Recalculates remaining time from wall-clock elapsed. If the rest period has
+  // ended, fires onExpired and clears the timer. Safe to call anytime the timer
+  // may have drifted (screen wake, tab resume, etc.).
   recalcRestTimer(): void
 
   // Elapsed timer setter (owned by the workout log page, see Tech.md D-1)
@@ -597,9 +597,10 @@ export const useActiveWorkoutStore = create<ActiveWorkoutState & ActiveWorkoutAc
       set((state) => {
         if (!state.restTimer) return {}
         const { total, startedAt } = state.restTimer
-        // For positive delta: extend total so remaining grows (matches Rust behavior).
+        // For positive delta: extend total so remaining grows.
         // For negative delta: shift startedAt earlier so elapsed increases and remaining
-        // shrinks -- total is unchanged (matches Rust behavior).
+        // shrinks -- total is unchanged. Note: Rust saturates via checked_sub on started_at;
+        // JS saturates via Math.max on remaining (startedAt may be over-shifted in state).
         const newTotal = delta >= 0 ? total + delta : total
         const newStartedAt = delta < 0 ? startedAt - (-delta) * 1000 : startedAt
         const newRemaining = Math.max(
@@ -684,18 +685,26 @@ export const useActiveWorkoutStore = create<ActiveWorkoutState & ActiveWorkoutAc
       const state = get()
       if (!state.restTimer) return
 
-      const newRemaining = state.restTimer.remaining - 1
+      const newRemaining = Math.max(
+        0,
+        Math.round(state.restTimer.total - (Date.now() - state.restTimer.startedAt) / 1000),
+      )
 
       if (newRemaining <= 0) {
         // Rest complete -- auto-skip
-        _onRestExpired?.()
-        _onRestExpired = null
-        if (_restInterval) {
-          clearInterval(_restInterval)
-          _restInterval = null
+        try {
+          _onRestExpired?.()
+        } catch (err) {
+          console.error('[rest-timer] onExpired callback threw:', err)
+        } finally {
+          _onRestExpired = null
+          if (_restInterval) {
+            clearInterval(_restInterval)
+            _restInterval = null
+          }
+          set({ restTimer: null })
+          _publishCurrentState()
         }
-        set({ restTimer: null })
-        _publishCurrentState()
         return
       }
 
@@ -712,14 +721,27 @@ export const useActiveWorkoutStore = create<ActiveWorkoutState & ActiveWorkoutAc
       const newRemaining = Math.max(0, Math.round(total - (Date.now() - startedAt) / 1000))
 
       if (newRemaining <= 0) {
-        _onRestExpired?.()
-        _onRestExpired = null
-        if (_restInterval) {
-          clearInterval(_restInterval)
-          _restInterval = null
+        // Mirror skipRest: stop Rust timer and clean listeners (Tauri), or clear JS interval.
+        if (isTauri()) {
+          invoke('skip_rest_timer').catch((err) => {
+            console.error('[rest-timer] Failed to cancel expired timer:', err)
+          })
+          _cleanupTauriRestListeners()
+        } else {
+          if (_restInterval) {
+            clearInterval(_restInterval)
+            _restInterval = null
+          }
         }
-        set({ restTimer: null })
-        _publishCurrentState()
+        try {
+          _onRestExpired?.()
+        } catch (err) {
+          console.error('[rest-timer] onExpired callback threw:', err)
+        } finally {
+          _onRestExpired = null
+          set({ restTimer: null })
+          _publishCurrentState()
+        }
         return
       }
 

--- a/src/stores/active-workout-store.ts
+++ b/src/stores/active-workout-store.ts
@@ -46,6 +46,7 @@ export interface UndoAction {
 interface RestTimer {
   remaining: number
   total: number
+  startedAt: number // Date.now() ms when this rest period began
 }
 
 // ---------------------------------------------------------------------------
@@ -167,6 +168,10 @@ interface ActiveWorkoutActions {
   ): void
   skipRest(): void
   adjustRest(delta: number): void
+  // Snaps the rest timer to wall-clock reality -- called by the foreground
+  // detector when the screen wakes after being off. Fires onExpired if the
+  // rest period ended while the screen was dark.
+  recalcRestTimer(): void
 
   // Elapsed timer setter (owned by the workout log page, see Tech.md D-1)
   setElapsedSeconds(seconds: number): void
@@ -504,8 +509,9 @@ export const useActiveWorkoutStore = create<ActiveWorkoutState & ActiveWorkoutAc
       if (_restInterval) clearInterval(_restInterval)
       _cleanupTauriRestListeners()
 
+      const startedAt = Date.now()
       set({
-        restTimer: { remaining: seconds, total: seconds },
+        restTimer: { remaining: seconds, total: seconds, startedAt },
       })
       _publishCurrentState()
 
@@ -515,13 +521,16 @@ export const useActiveWorkoutStore = create<ActiveWorkoutState & ActiveWorkoutAc
         // Rust-backed timer: register listeners BEFORE invoking the command
         // to avoid missing early tick/expired events.
         Promise.all([
-          listen<{ remaining: number }>('timer_tick', (event) => {
-            set({
-              restTimer: {
-                remaining: event.payload.remaining,
-                total: get().restTimer?.total ?? seconds,
-              },
-            })
+          listen<{ remaining: number; total: number }>('timer_tick', (event) => {
+            set((state) => ({
+              restTimer: state.restTimer
+                ? {
+                    ...state.restTimer,
+                    remaining: event.payload.remaining,
+                    total: event.payload.total,
+                  }
+                : null,
+            }))
           }).then((fn) => {
             _unlistenTick = fn
           }),
@@ -587,14 +596,18 @@ export const useActiveWorkoutStore = create<ActiveWorkoutState & ActiveWorkoutAc
       // update before converging.
       set((state) => {
         if (!state.restTimer) return {}
-        const newRemaining = Math.max(0, state.restTimer.remaining + delta)
-        // For negative delta: only change remaining, not total (matches Rust behavior)
-        const newTotal = delta >= 0 ? state.restTimer.total + delta : state.restTimer.total
+        const { total, startedAt } = state.restTimer
+        // For positive delta: extend total so remaining grows (matches Rust behavior).
+        // For negative delta: shift startedAt earlier so elapsed increases and remaining
+        // shrinks -- total is unchanged (matches Rust behavior).
+        const newTotal = delta >= 0 ? total + delta : total
+        const newStartedAt = delta < 0 ? startedAt - (-delta) * 1000 : startedAt
+        const newRemaining = Math.max(
+          0,
+          Math.round(newTotal - (Date.now() - newStartedAt) / 1000),
+        )
         return {
-          restTimer: {
-            remaining: newRemaining,
-            total: newTotal,
-          },
+          restTimer: { ...state.restTimer, total: newTotal, startedAt: newStartedAt, remaining: newRemaining },
         }
       })
       _publishCurrentState()
@@ -689,6 +702,29 @@ export const useActiveWorkoutStore = create<ActiveWorkoutState & ActiveWorkoutAc
       set({
         restTimer: { ...state.restTimer, remaining: newRemaining },
       })
+    },
+
+    recalcRestTimer() {
+      const state = get()
+      if (!state.restTimer) return
+
+      const { total, startedAt } = state.restTimer
+      const newRemaining = Math.max(0, Math.round(total - (Date.now() - startedAt) / 1000))
+
+      if (newRemaining <= 0) {
+        _onRestExpired?.()
+        _onRestExpired = null
+        if (_restInterval) {
+          clearInterval(_restInterval)
+          _restInterval = null
+        }
+        set({ restTimer: null })
+        _publishCurrentState()
+        return
+      }
+
+      set({ restTimer: { ...state.restTimer, remaining: newRemaining } })
+      _publishCurrentState()
     },
 
     // ------------------------------------------------------------------

--- a/src/stores/active-workout-store.ts
+++ b/src/stores/active-workout-store.ts
@@ -168,7 +168,8 @@ interface ActiveWorkoutActions {
   ): void
   skipRest(): void
   adjustRest(delta: number): void
-  // Recalculates remaining time from wall-clock elapsed. If the rest period has
+  // Recalculates remaining time from wall-clock elapsed. If still running,
+  // corrects remaining to the current wall-clock value. If the rest period has
   // ended, fires onExpired and clears the timer. Safe to call anytime the timer
   // may have drifted (screen wake, tab resume, etc.).
   recalcRestTimer(): void


### PR DESCRIPTION
## Summary

- **Root cause**: Both the rest timer and elapsed timer used tick-accumulation (decrement/increment per interval). When the mobile screen times out, the JS runtime and tokio async tasks are suspended, so ticks stop accumulating. Displays freeze and rest expiry fires late.
- **Fix**: Convert all timer math to wall-clock timestamps so the next tick after wake self-corrects to the right value regardless of how long the screen was off.
- **Foreground snap**: Wire the existing `createForegroundDetector` into the log page so both timers update instantly when the screen turns back on, not just on the next scheduled tick.

## Test plan

- [ ] Start a workout, let the screen time out mid-rest, unlock -- rest timer should show the correct remaining time immediately (not the stale pre-sleep value)
- [ ] If the rest period ends while the screen is off, unlocking should fire `onExpired` immediately and dismiss the rest banner
- [ ] Elapsed workout timer should show the correct total time after wake (no gap/freeze artifacts)
- [ ] Adjust rest (+/- buttons) still works correctly before and after a screen wake
- [ ] `bun run test` passes (2496 tests)
- [ ] `cargo test --lib` passes (85 tests)